### PR TITLE
Fix steam library validity test

### DIFF
--- a/src/core/models.rs
+++ b/src/core/models.rs
@@ -147,7 +147,9 @@ mod tests {
     #[test]
     fn test_steam_library_creation() {
         let temp_dir = tempdir().unwrap();
-        
+        // Create the steamapps directory to satisfy `is_valid` checks
+        std::fs::create_dir(temp_dir.path().join("steamapps")).unwrap();
+
         // Test valid library
         let library = SteamLibrary::new(temp_dir.path().to_path_buf()).unwrap();
         assert_eq!(library.path(), temp_dir.path());


### PR DESCRIPTION
## Summary
- fix steam library unit test by creating `steamapps` path before verifying `is_valid`

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ccf559cc8333835828dfc213d55a