### PR TITLE
Rename project to Proton Prefix Manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -206,33 +206,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -2653,7 +2653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
 
 [[package]]
-name = "proton-prefix-finder"
+name = "proton-prefix-manager"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "proton-prefix-finder"
+name = "proton-prefix-manager"
 version = "0.1.0"
 edition = "2024"
 description = "A tool to find and manage Proton prefixes for Steam games on Linux"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Proton Prefix Finder
+# Proton Prefix Manager
 
-Proton Prefix Finder is a tool for locating and exploring the Proton prefixes created by Steam on Linux. It offers both a command line interface and a simple graphical interface built with [egui](https://github.com/emilk/egui).
+Proton Prefix Manager is a tool for locating and exploring the Proton prefixes created by Steam on Linux. It offers both a command line interface and a simple graphical interface built with [egui](https://github.com/emilk/egui).
 
 ## Overview
 
@@ -15,7 +15,7 @@ Steam uses Proton prefixes (Wine environments) to run Windows games on Linux. Th
    cd proton-prefix-manager
    cargo build --release
    ```
-   The resulting binary will be located at `target/release/proton-prefix-finder`.
+   The resulting binary will be located at `target/release/proton-prefix-manager`.
 
 Alternatively, you can install directly from the source using:
 
@@ -30,7 +30,7 @@ cargo install --path .
 Run the program without arguments to launch the GUI:
 
 ```bash
-proton-prefix-finder
+proton-prefix-manager
 ```
 
 The GUI lists your installed Steam games and shows details about each prefix. You can copy or open the prefix path and follow external links such as SteamDB or ProtonDB.
@@ -40,19 +40,19 @@ The GUI lists your installed Steam games and shows details about each prefix. Yo
 Search for games by name:
 
 ```bash
-proton-prefix-finder search "portal"
+proton-prefix-manager search "portal"
 ```
 
 Find the prefix path for a specific AppID:
 
 ```bash
-proton-prefix-finder prefix 620
+proton-prefix-manager prefix 620
 ```
 
 Open a prefix in your file manager:
 
 ```bash
-proton-prefix-finder open 620
+proton-prefix-manager open 620
 ```
 
 The CLI supports JSON (`--json`), plain text (`--plain`), and custom-delimited output using `--delimiter`.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,13 +4,13 @@ pub mod search;
 pub mod prefix;
 pub mod open;
 
-/// Proton Prefix Finder CLI
+/// Proton Prefix Manager CLI
 /// 
 /// A tool to find and manage Proton prefixes for Steam games.
 /// Run without arguments to launch the GUI.
 /// Each command has its own options - use --help with a command to see them.
 #[derive(Parser)]
-#[command(name = "proton-prefix-finder")]
+#[command(name = "proton-prefix-manager")]
 #[command(about = "Find and manage Proton prefixes easily", long_about = None)]
 pub struct Cli {
     #[command(subcommand)]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,4 @@
-//! Core functionality for the Proton Prefix Finder.
+//! Core functionality for the Proton Prefix Manager.
 //! 
 //! This module contains the core functionality that is shared between
 //! the CLI and GUI interfaces, including data models and Steam operations.

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -6,7 +6,7 @@ use crate::core::steam;
 use super::game_list::GameList;
 use super::details::GameDetails;
 
-pub struct ProtonPrefixFinderApp {
+pub struct ProtonPrefixManagerApp {
     loading: bool,
     search_query: String,
     installed_games: Arc<Mutex<Vec<GameInfo>>>,
@@ -19,7 +19,7 @@ pub struct ProtonPrefixFinderApp {
     load_error: Option<String>,
 }
 
-impl Default for ProtonPrefixFinderApp {
+impl Default for ProtonPrefixManagerApp {
     fn default() -> Self {
         Self {
             loading: true,
@@ -36,7 +36,7 @@ impl Default for ProtonPrefixFinderApp {
     }
 }
 
-impl ProtonPrefixFinderApp {
+impl ProtonPrefixManagerApp {
     pub fn new() -> Self {
         let app = Self::default();
         let games = Arc::clone(&app.installed_games);
@@ -128,7 +128,7 @@ impl ProtonPrefixFinderApp {
     }
 }
 
-impl eframe::App for ProtonPrefixFinderApp {
+impl eframe::App for ProtonPrefixManagerApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Apply theme
         self.apply_theme(ctx);
@@ -168,7 +168,7 @@ impl eframe::App for ProtonPrefixFinderApp {
 
         egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
             ui.horizontal(|ui| {
-                ui.heading("Proton Prefix Finder");
+                ui.heading("Proton Prefix Manager");
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     if ui.button(if self.dark_mode { "☀" } else { "🌙" }).clicked() {
                         self.toggle_theme(ctx);
@@ -214,7 +214,7 @@ impl eframe::App for ProtonPrefixFinderApp {
                 }
                 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    ui.hyperlink_to("GitHub", "https://github.com/yourusername/proton-prefix-finder");
+                    ui.hyperlink_to("GitHub", "https://github.com/yourusername/proton-prefix-manager");
                 });
             });
         });

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2,4 +2,4 @@ mod app;
 mod game_list;
 mod details;
 
-pub use app::ProtonPrefixFinderApp;
+pub use app::ProtonPrefixManagerApp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-//! # Proton Prefix Finder
+//! # Proton Prefix Manager
 //! 
 //! A tool to find and manage Proton prefixes for Steam games on Linux.
 //! 
@@ -14,25 +14,25 @@
 //! Run without arguments to launch the GUI:
 //! 
 //! ```
-//! proton-prefix-finder
+//! proton-prefix-manager
 //! ```
 //! 
 //! Search for games by name:
 //! 
 //! ```
-//! proton-prefix-finder search "portal"
+//! proton-prefix-manager search "portal"
 //! ```
 //! 
 //! Find a prefix for a specific AppID:
 //! 
 //! ```
-//! proton-prefix-finder prefix 620
+//! proton-prefix-manager prefix 620
 //! ```
 //! 
 //! Open a prefix in your file manager:
 //! 
 //! ```
-//! proton-prefix-finder open 620
+//! proton-prefix-manager open 620
 //! ```
 
 use clap::Parser;
@@ -45,7 +45,7 @@ mod core;
 mod error;
 
 use cli::{Cli, Commands};
-use gui::ProtonPrefixFinderApp;
+use gui::ProtonPrefixManagerApp;
 use utils::output::determine_format;
 
 fn main() {
@@ -69,9 +69,9 @@ fn main() {
             log::info!("Launching GUI...");
             let native_options = NativeOptions::default();
             eframe::run_native(
-                "Proton Prefix Finder",
+                "Proton Prefix Manager",
                 native_options,
-                Box::new(|_cc| Ok(Box::new(ProtonPrefixFinderApp::new()))),
+                Box::new(|_cc| Ok(Box::new(ProtonPrefixManagerApp::new()))),
             ).expect("Failed to start GUI");
         }
     }


### PR DESCRIPTION
## Summary
- rename all references of Proton Prefix Finder to Proton Prefix Manager
- update cargo crate name, docs and GUI strings

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6840d20a7e348333a1d52d46054a8059