### PR TITLE
Add CLI open and prefix tests

### DIFF
--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -1,5 +1,24 @@
 use crate::core::steam;
 
+#[cfg(test)]
+use once_cell::sync::Lazy;
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(not(test))]
+fn open_path(path: &std::path::Path) -> std::io::Result<()> {
+    open::that(path)
+}
+
+#[cfg(test)]
+pub static OPENED_PATHS: Lazy<Mutex<Vec<std::path::PathBuf>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+#[cfg(test)]
+fn open_path(path: &std::path::Path) -> std::io::Result<()> {
+    OPENED_PATHS.lock().unwrap().push(path.to_path_buf());
+    Ok(())
+}
+
 pub fn execute(appid: u32) {
     println!("📂 Opening Proton prefix for AppID: {}", appid);
     
@@ -7,7 +26,7 @@ pub fn execute(appid: u32) {
         Ok(libraries) => {
             if let Some(prefix_path) = steam::find_proton_prefix(appid, &libraries) {
                 println!("🗂  Opening folder: {}", prefix_path.display());
-                if let Err(e) = open::that(&prefix_path) {
+                if let Err(e) = open_path(&prefix_path) {
                     eprintln!("❌ Failed to open folder: {}", e);
                 }
             } else {
@@ -18,4 +37,69 @@ pub fn execute(appid: u32) {
             eprintln!("❌ Error: {}", err);
         }
     }
-} 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+    use crate::test_helpers::TEST_MUTEX;
+
+    fn setup_mock_steam(appid: u32) -> (tempfile::TempDir, std::path::PathBuf) {
+        let home = tempdir().unwrap();
+        let config_dir = home.path().join(".steam/steam/config");
+        fs::create_dir_all(&config_dir).unwrap();
+
+        let library_dir = home.path().join("library");
+        let compat_path = library_dir.join("steamapps/compatdata").join(appid.to_string());
+        fs::create_dir_all(&compat_path).unwrap();
+
+        let vdf_path = config_dir.join("libraryfolders.vdf");
+        let content = format!(
+            "\"libraryfolders\" {{\n    \"0\" {{\n        \"path\" \"{}\"\n    }}\n}}",
+            library_dir.display()
+        );
+        fs::write(&vdf_path, content).unwrap();
+
+        (home, compat_path)
+    }
+
+    #[test]
+    fn test_execute_opens_prefix() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let appid = 5555;
+        let (home, prefix) = setup_mock_steam(appid);
+        let old_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", home.path()); }
+
+        OPENED_PATHS.lock().unwrap().clear();
+        execute(appid);
+
+        let opened = OPENED_PATHS.lock().unwrap();
+        assert_eq!(opened.len(), 1);
+        assert_eq!(opened[0], prefix);
+
+        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+    }
+
+    #[test]
+    fn test_execute_no_prefix() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let appid = 6666;
+        let (home, prefix) = setup_mock_steam(appid);
+        fs::remove_dir_all(&prefix).unwrap();
+        let old_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", home.path()); }
+
+        OPENED_PATHS.lock().unwrap().clear();
+        execute(appid);
+
+        let opened = OPENED_PATHS.lock().unwrap();
+        assert!(opened.is_empty());
+
+        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+    }
+}

--- a/src/cli/prefix.rs
+++ b/src/cli/prefix.rs
@@ -2,6 +2,24 @@ use crate::core::steam;
 use crate::utils::output;
 use crate::utils::output::OutputFormat;
 
+#[cfg(test)]
+use once_cell::sync::Lazy;
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(not(test))]
+fn emit_prefix_result(appid: u32, prefix: Option<std::path::PathBuf>, format: &OutputFormat) {
+    output::print_prefix_result(appid, prefix, format);
+}
+
+#[cfg(test)]
+pub static PREFIX_RESULTS: Lazy<Mutex<Vec<(u32, Option<std::path::PathBuf>)>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+#[cfg(test)]
+fn emit_prefix_result(appid: u32, prefix: Option<std::path::PathBuf>, _format: &OutputFormat) {
+    PREFIX_RESULTS.lock().unwrap().push((appid, prefix));
+}
+
 pub fn execute(appid: u32, format: &OutputFormat) {
     if matches!(format, OutputFormat::Normal) {
         println!("🔍 Locating Proton prefix for AppID: {}", appid);
@@ -10,10 +28,77 @@ pub fn execute(appid: u32, format: &OutputFormat) {
     match steam::get_steam_libraries() {
         Ok(libraries) => {
             let prefix = steam::find_proton_prefix(appid, &libraries);
-            output::print_prefix_result(appid, prefix, format);
+            emit_prefix_result(appid, prefix, format);
         },
         Err(err) => {
             eprintln!("❌ Error: {}", err);
         }
     }
-} 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+    use crate::test_helpers::TEST_MUTEX;
+
+    fn setup_mock_steam(appid: u32) -> (tempfile::TempDir, std::path::PathBuf) {
+        let home = tempdir().unwrap();
+        let config_dir = home.path().join(".steam/steam/config");
+        fs::create_dir_all(&config_dir).unwrap();
+
+        let library_dir = home.path().join("library");
+        let compat_path = library_dir.join("steamapps/compatdata").join(appid.to_string());
+        fs::create_dir_all(&compat_path).unwrap();
+
+        let vdf_path = config_dir.join("libraryfolders.vdf");
+        let content = format!(
+            "\"libraryfolders\" {{\n    \"0\" {{\n        \"path\" \"{}\"\n    }}\n}}",
+            library_dir.display()
+        );
+        fs::write(&vdf_path, content).unwrap();
+
+        (home, compat_path)
+    }
+
+    #[test]
+    fn test_execute_prefix_found() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let appid = 4242;
+        let (home, prefix) = setup_mock_steam(appid);
+        let old_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", home.path()); }
+
+        PREFIX_RESULTS.lock().unwrap().clear();
+        execute(appid, &OutputFormat::Plain);
+
+        let results = PREFIX_RESULTS.lock().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, appid);
+        assert_eq!(results[0].1.as_ref().unwrap(), &prefix);
+
+        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+    }
+
+    #[test]
+    fn test_execute_prefix_missing() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let appid = 1337;
+        let (home, prefix) = setup_mock_steam(appid);
+        fs::remove_dir_all(&prefix).unwrap();
+        let old_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", home.path()); }
+
+        PREFIX_RESULTS.lock().unwrap().clear();
+        execute(appid, &OutputFormat::Plain);
+
+        let results = PREFIX_RESULTS.lock().unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.is_none());
+
+        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+    }
+}

--- a/src/core/steam.rs
+++ b/src/core/steam.rs
@@ -30,6 +30,12 @@ struct ManifestCache {
 static LIBRARY_CACHE: Lazy<Mutex<Option<LibraryCache>>> = Lazy::new(|| Mutex::new(None));
 static MANIFEST_CACHE: Lazy<Mutex<Option<ManifestCache>>> = Lazy::new(|| Mutex::new(None));
 
+#[cfg(test)]
+pub fn clear_caches() {
+    *LIBRARY_CACHE.lock().unwrap() = None;
+    *MANIFEST_CACHE.lock().unwrap() = None;
+}
+
 // Cache duration (5 seconds)
 const CACHE_DURATION: std::time::Duration = std::time::Duration::from_secs(5);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,9 @@ mod utils;
 mod core;
 mod error;
 
+#[cfg(test)]
+mod test_helpers;
+
 use cli::{Cli, Commands};
 use gui::ProtonPrefixFinderApp;
 use utils::output::determine_format;

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+use once_cell::sync::Lazy;
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(test)]
+pub static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));


### PR DESCRIPTION
## Summary
- add cross-module test mutex and cache clearing helpers
- wrap open path and prefix output for testability
- implement tests for `cli::prefix::execute` and `cli::open::execute`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6840d1bcf23c8333bc7de36c9490c268