### PR TITLE
Set Rust edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proton-prefix-finder"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 description = "A tool to find and manage Proton prefixes for Steam games on Linux"
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- update project edition from Rust 2024 to the latest stable edition 2021

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6840d1b93e8c833384c60d33f11d177b