### PR TITLE
Add backup and restore features

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ Open a prefix in your file manager:
 proton-prefix-finder open 620
 ```
 
+Back up a prefix to a directory:
+
+```bash
+proton-prefix-finder backup 620 /path/to/backup
+```
+
+Restore a prefix from a backup:
+
+```bash
+proton-prefix-finder restore 620 /path/to/backup
+```
+
 The CLI supports JSON (`--json`), plain text (`--plain`), and custom-delimited output using `--delimiter`.
 
 ## Project goals

--- a/src/cli/backup.rs
+++ b/src/cli/backup.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+
+use crate::core::steam;
+use crate::utils::backup as backup_utils;
+
+pub fn execute(appid: u32, destination: PathBuf) {
+    println!("📦 Backing up Proton prefix for AppID: {}", appid);
+
+    match steam::get_steam_libraries() {
+        Ok(libraries) => {
+            if let Some(prefix_path) = steam::find_proton_prefix(appid, &libraries) {
+                match backup_utils::backup_prefix(&prefix_path, &destination) {
+                    Ok(path) => println!("✅ Backup created at {}", path.display()),
+                    Err(e) => eprintln!("❌ Failed to back up prefix: {}", e),
+                }
+            } else {
+                println!("❌ Proton prefix not found for AppID: {}", appid);
+            }
+        }
+        Err(err) => {
+            eprintln!("❌ Error: {}", err);
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,8 +1,11 @@
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 pub mod search;
 pub mod prefix;
 pub mod open;
+pub mod backup;
+pub mod restore;
 
 /// Proton Prefix Finder CLI
 /// 
@@ -59,5 +62,23 @@ pub enum Commands {
     Open {
         /// The Steam App ID of the game
         appid: u32,
+    },
+
+    /// Back up the Proton prefix to a directory
+    Backup {
+        /// The Steam App ID of the game
+        appid: u32,
+
+        /// Destination directory for the backup
+        path: PathBuf,
+    },
+
+    /// Restore the Proton prefix from a backup directory
+    Restore {
+        /// The Steam App ID of the game
+        appid: u32,
+
+        /// Path to the backup directory
+        path: PathBuf,
     },
 }

--- a/src/cli/restore.rs
+++ b/src/cli/restore.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+
+use crate::core::steam;
+use crate::utils::backup as backup_utils;
+
+pub fn execute(appid: u32, backup_path: PathBuf) {
+    println!("♻️ Restoring Proton prefix for AppID: {}", appid);
+
+    match steam::get_steam_libraries() {
+        Ok(libraries) => {
+            if let Some(prefix_path) = steam::find_proton_prefix(appid, &libraries) {
+                match backup_utils::restore_prefix(&backup_path, &prefix_path) {
+                    Ok(path) => println!("✅ Prefix restored to {}", path.display()),
+                    Err(e) => eprintln!("❌ Failed to restore prefix: {}", e),
+                }
+            } else {
+                println!("❌ Proton prefix not found for AppID: {}", appid);
+            }
+        }
+        Err(err) => {
+            eprintln!("❌ Error: {}", err);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 //! - Find Proton prefixes for specific games
 //! - Open prefixes in your file manager
 //! - GUI and CLI interfaces
+//! - Back up and restore prefixes
 //! 
 //! ## Usage
 //! 
@@ -64,6 +65,12 @@ fn main() {
         }
         Some(Commands::Open { appid }) => {
             cli::open::execute(*appid);
+        }
+        Some(Commands::Backup { appid, path }) => {
+            cli::backup::execute(*appid, path.clone());
+        }
+        Some(Commands::Restore { appid, path }) => {
+            cli::restore::execute(*appid, path.clone());
         }
         None => {
             log::info!("Launching GUI...");

--- a/src/utils/backup.rs
+++ b/src/utils/backup.rs
@@ -1,0 +1,79 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    if !dst.exists() {
+        fs::create_dir_all(dst)?;
+    }
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let dest_path = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&entry.path(), &dest_path)?;
+        } else {
+            fs::copy(entry.path(), dest_path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Back up a Proton prefix by copying it to the given destination directory.
+pub fn backup_prefix(prefix_path: &Path, backup_path: &Path) -> Result<PathBuf> {
+    if !prefix_path.exists() {
+        return Err(Error::FileSystemError(format!(
+            "Prefix not found: {}",
+            prefix_path.display()
+        )));
+    }
+    if backup_path.exists() {
+        return Err(Error::FileSystemError(format!(
+            "Backup destination already exists: {}",
+            backup_path.display()
+        )));
+    }
+    copy_dir_recursive(prefix_path, backup_path)?;
+    Ok(backup_path.to_path_buf())
+}
+
+/// Restore a Proton prefix from a backup directory.
+pub fn restore_prefix(backup_path: &Path, prefix_path: &Path) -> Result<PathBuf> {
+    if !backup_path.exists() {
+        return Err(Error::FileSystemError(format!(
+            "Backup not found: {}",
+            backup_path.display()
+        )));
+    }
+
+    if prefix_path.exists() {
+        fs::remove_dir_all(prefix_path)?;
+    }
+    copy_dir_recursive(backup_path, prefix_path)?;
+    Ok(prefix_path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use std::io::Write;
+
+    #[test]
+    fn test_backup_and_restore() {
+        let dir = tempdir().unwrap();
+        let prefix = dir.path().join("prefix");
+        let backup = dir.path().join("backup");
+        fs::create_dir_all(prefix.join("sub")).unwrap();
+        let mut f = fs::File::create(prefix.join("sub/file.txt")).unwrap();
+        writeln!(f, "test").unwrap();
+
+        backup_prefix(&prefix, &backup).unwrap();
+        assert!(backup.join("sub/file.txt").exists());
+
+        fs::remove_dir_all(&prefix).unwrap();
+        restore_prefix(&backup, &prefix).unwrap();
+        assert!(prefix.join("sub/file.txt").exists());
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,3 +2,4 @@
 pub mod proton;
 pub mod library;
 pub mod output;
+pub mod backup;


### PR DESCRIPTION
## Summary
- implement backup and restore utilities
- expose new `backup` and `restore` CLI commands
- support backing up prefixes and restoring from a backup directory
- document new commands in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6840d1b775bc8333b9c8a9ebbebe6da7