### PR TITLE
Reduce build memory usage

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+jobs = 2

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Steam uses Proton prefixes (Wine environments) to run Windows games on Linux. Th
    ```
    The resulting binary will be located at `target/release/proton-prefix-manager`.
 
+   If compilation uses too much memory or CPU on your system, you can limit the
+   number of parallel build jobs:
+
+   ```bash
+   cargo build --release --jobs 2
+   ```
+   Alternatively, create a `.cargo/config.toml` file with:
+
+   ```toml
+   [build]
+   jobs = 2
+   ```
+
 Alternatively, you can install directly from the source using:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a `.cargo/config.toml` with `jobs = 2` to limit parallel compilation
- document how to limit build jobs in the README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6840d53ef5a88333b87a9f128a057459