### PR TITLE
Improve backup handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,40 @@ Open a prefix in your file manager:
 proton-prefix-manager open 620
 ```
 
-Back up a prefix to a directory:
+Back up a prefix (stored in `~/.local/share/proton-prefix-manager/backups`):
 
 ```bash
-proton-prefix-manager backup 620 /path/to/backup
+proton-prefix-manager backup 620
 ```
 
-Restore a prefix from a backup:
+Restore a prefix from a backup directory:
 
 ```bash
 proton-prefix-manager restore 620 /path/to/backup
+```
+
+List backups for a game:
+
+```bash
+proton-prefix-manager list-backups 620
+```
+
+Delete a backup:
+
+```bash
+proton-prefix-manager delete-backup 620 /path/to/backup
+```
+
+Reset a prefix:
+
+```bash
+proton-prefix-manager reset 620
+```
+
+Clear shader cache:
+
+```bash
+proton-prefix-manager clear-cache 620
 ```
 
 The CLI supports JSON (`--json`), plain text (`--plain`), and custom-delimited output using `--delimiter`.

--- a/src/cli/backup.rs
+++ b/src/cli/backup.rs
@@ -1,15 +1,13 @@
-use std::path::PathBuf;
-
 use crate::core::steam;
 use crate::utils::backup as backup_utils;
 
-pub fn execute(appid: u32, destination: PathBuf) {
+pub fn execute(appid: u32) {
     println!("📦 Backing up Proton prefix for AppID: {}", appid);
 
     match steam::get_steam_libraries() {
         Ok(libraries) => {
             if let Some(prefix_path) = steam::find_proton_prefix(appid, &libraries) {
-                match backup_utils::backup_prefix(&prefix_path, &destination) {
+                match backup_utils::create_backup(&prefix_path, appid) {
                     Ok(path) => println!("✅ Backup created at {}", path.display()),
                     Err(e) => eprintln!("❌ Failed to back up prefix: {}", e),
                 }

--- a/src/cli/clear_cache.rs
+++ b/src/cli/clear_cache.rs
@@ -1,0 +1,12 @@
+use crate::core::steam;
+use crate::utils::backup as backup_utils;
+
+pub fn execute(appid: u32) {
+    match steam::get_steam_libraries() {
+        Ok(libs) => match backup_utils::clear_shader_cache(appid, &libs) {
+            Ok(_) => println!("Shader cache cleared"),
+            Err(e) => eprintln!("Failed to clear shader cache: {}", e),
+        },
+        Err(e) => eprintln!("❌ Error: {}", e),
+    }
+}

--- a/src/cli/delete_backup.rs
+++ b/src/cli/delete_backup.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+use crate::core::steam;
+use crate::utils::backup as backup_utils;
+
+pub fn execute(appid: u32, backup: PathBuf) {
+    match steam::get_steam_libraries() {
+        Ok(_libs) => match backup_utils::delete_backup(&backup) {
+            Ok(_) => println!("Deleted backup {}", backup.display()),
+            Err(e) => eprintln!("Failed to delete backup: {}", e),
+        },
+        Err(err) => eprintln!("❌ Error: {}", err),
+    }
+}

--- a/src/cli/list_backups.rs
+++ b/src/cli/list_backups.rs
@@ -1,0 +1,18 @@
+use crate::core::steam;
+use crate::utils::backup as backup_utils;
+
+pub fn execute(appid: u32) {
+    match steam::get_steam_libraries() {
+        Ok(_libs) => {
+            let backups = backup_utils::list_backups(appid);
+            if backups.is_empty() {
+                println!("No backups found");
+            } else {
+                for b in backups {
+                    println!("{}", b.display());
+                }
+            }
+        }
+        Err(err) => eprintln!("❌ Error: {}", err),
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,14 +1,18 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
-pub mod search;
-pub mod prefix;
-pub mod open;
 pub mod backup;
+pub mod clear_cache;
+pub mod delete_backup;
+pub mod list_backups;
+pub mod open;
+pub mod prefix;
+pub mod reset;
 pub mod restore;
+pub mod search;
 
 /// Proton Prefix Manager CLI
-/// 
+///
 /// A tool to find and manage Proton prefixes for Steam games.
 /// Run without arguments to launch the GUI.
 /// Each command has its own options - use --help with a command to see them.
@@ -26,15 +30,15 @@ pub enum Commands {
     Search {
         /// The name of the game to search for
         name: String,
-        
+
         /// Output in JSON format
         #[arg(long)]
         json: bool,
-        
+
         /// Output in plain format (no formatting or emojis)
         #[arg(long)]
         plain: bool,
-        
+
         /// Specify custom delimiter for output
         #[arg(long)]
         delimiter: Option<String>,
@@ -44,15 +48,15 @@ pub enum Commands {
     Prefix {
         /// The Steam App ID of the game
         appid: u32,
-        
+
         /// Output in JSON format
         #[arg(long)]
         json: bool,
-        
+
         /// Output in plain format (no formatting or emojis)
         #[arg(long)]
         plain: bool,
-        
+
         /// Specify custom delimiter for output
         #[arg(long)]
         delimiter: Option<String>,
@@ -64,13 +68,10 @@ pub enum Commands {
         appid: u32,
     },
 
-    /// Back up the Proton prefix to a directory
+    /// Back up the Proton prefix to the default backup location
     Backup {
         /// The Steam App ID of the game
         appid: u32,
-
-        /// Destination directory for the backup
-        path: PathBuf,
     },
 
     /// Restore the Proton prefix from a backup directory
@@ -80,5 +81,32 @@ pub enum Commands {
 
         /// Path to the backup directory
         path: PathBuf,
+    },
+
+    /// List backups for the given App ID
+    ListBackups {
+        /// The Steam App ID of the game
+        appid: u32,
+    },
+
+    /// Delete a specific backup
+    DeleteBackup {
+        /// The Steam App ID of the game
+        appid: u32,
+
+        /// Path to the backup directory
+        backup: PathBuf,
+    },
+
+    /// Delete the existing prefix
+    Reset {
+        /// The Steam App ID of the game
+        appid: u32,
+    },
+
+    /// Clear the shader cache for the given App ID
+    ClearCache {
+        /// The Steam App ID of the game
+        appid: u32,
     },
 }

--- a/src/cli/reset.rs
+++ b/src/cli/reset.rs
@@ -1,0 +1,18 @@
+use crate::core::steam;
+use crate::utils::backup as backup_utils;
+
+pub fn execute(appid: u32) {
+    match steam::get_steam_libraries() {
+        Ok(libraries) => {
+            if let Some(prefix) = steam::find_proton_prefix(appid, &libraries) {
+                match backup_utils::reset_prefix(&prefix) {
+                    Ok(_) => println!("Prefix deleted"),
+                    Err(e) => eprintln!("Failed to delete prefix: {}", e),
+                }
+            } else {
+                println!("Prefix not found for {}", appid);
+            }
+        }
+        Err(e) => eprintln!("❌ Error: {}", e),
+    }
+}

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -1,10 +1,11 @@
 use crate::core::models::GameInfo;
+use crate::core::steam;
 use crate::utils::backup as backup_utils;
-use tinyfiledialogs as tfd;
 use eframe::egui;
 use std::fs;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tinyfiledialogs as tfd;
 
 pub struct GameDetails<'a> {
     game: Option<&'a GameInfo>,
@@ -108,20 +109,84 @@ impl<'a> GameDetails<'a> {
 
                     ui.horizontal(|ui| {
                         if ui.button("📦 Backup").clicked() {
-                            if let Some(dir) = tfd::select_folder_dialog("Select backup directory", "") {
-                                let path = std::path::PathBuf::from(dir);
-                                match backup_utils::backup_prefix(game.prefix_path(), &path) {
-                                    Ok(p) => tfd::message_box_ok("Backup", &format!("Backup created at {}", p.display()), tfd::MessageBoxIcon::Info),
-                                    Err(e) => tfd::message_box_ok("Backup failed", &format!("{}", e), tfd::MessageBoxIcon::Error),
-                                }
+                            match backup_utils::create_backup(game.prefix_path(), game.app_id()) {
+                                Ok(p) => tfd::message_box_ok(
+                                    "Backup",
+                                    &format!("Backup created at {}", p.display()),
+                                    tfd::MessageBoxIcon::Info,
+                                ),
+                                Err(e) => tfd::message_box_ok(
+                                    "Backup failed",
+                                    &format!("{}", e),
+                                    tfd::MessageBoxIcon::Error,
+                                ),
                             }
                         }
                         if ui.button("♻️ Restore").clicked() {
-                            if let Some(dir) = tfd::select_folder_dialog("Select backup to restore", "") {
+                            if let Some(dir) =
+                                tfd::select_folder_dialog("Select backup to restore", "")
+                            {
                                 let path = std::path::PathBuf::from(dir);
                                 match backup_utils::restore_prefix(&path, game.prefix_path()) {
-                                    Ok(_) => tfd::message_box_ok("Restore", "Prefix restored", tfd::MessageBoxIcon::Info),
-                                    Err(e) => tfd::message_box_ok("Restore failed", &format!("{}", e), tfd::MessageBoxIcon::Error),
+                                    Ok(_) => tfd::message_box_ok(
+                                        "Restore",
+                                        "Prefix restored",
+                                        tfd::MessageBoxIcon::Info,
+                                    ),
+                                    Err(e) => tfd::message_box_ok(
+                                        "Restore failed",
+                                        &format!("{}", e),
+                                        tfd::MessageBoxIcon::Error,
+                                    ),
+                                }
+                            }
+                        }
+                        if ui.button("🗑 Delete Backup").clicked() {
+                            if let Some(dir) =
+                                tfd::select_folder_dialog("Select backup to delete", "")
+                            {
+                                let path = std::path::PathBuf::from(dir);
+                                match backup_utils::delete_backup(&path) {
+                                    Ok(_) => tfd::message_box_ok(
+                                        "Delete",
+                                        "Backup removed",
+                                        tfd::MessageBoxIcon::Info,
+                                    ),
+                                    Err(e) => tfd::message_box_ok(
+                                        "Delete failed",
+                                        &format!("{}", e),
+                                        tfd::MessageBoxIcon::Error,
+                                    ),
+                                }
+                            }
+                        }
+                        if ui.button("🗑 Reset Prefix").clicked() {
+                            match backup_utils::reset_prefix(game.prefix_path()) {
+                                Ok(_) => tfd::message_box_ok(
+                                    "Reset",
+                                    "Prefix deleted",
+                                    tfd::MessageBoxIcon::Info,
+                                ),
+                                Err(e) => tfd::message_box_ok(
+                                    "Reset failed",
+                                    &format!("{}", e),
+                                    tfd::MessageBoxIcon::Error,
+                                ),
+                            }
+                        }
+                        if ui.button("🧹 Clear Cache").clicked() {
+                            if let Ok(libs) = steam::get_steam_libraries() {
+                                match backup_utils::clear_shader_cache(game.app_id(), &libs) {
+                                    Ok(_) => tfd::message_box_ok(
+                                        "Cache",
+                                        "Shader cache cleared",
+                                        tfd::MessageBoxIcon::Info,
+                                    ),
+                                    Err(e) => tfd::message_box_ok(
+                                        "Cache failed",
+                                        &format!("{}", e),
+                                        tfd::MessageBoxIcon::Error,
+                                    ),
                                 }
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,37 +1,37 @@
 //! # Proton Prefix Manager
-//! 
+//!
 //! A tool to find and manage Proton prefixes for Steam games on Linux.
-//! 
+//!
 //! ## Features
-//! 
+//!
 //! - Search for installed Steam games
 //! - Find Proton prefixes for specific games
 //! - Open prefixes in your file manager
 //! - GUI and CLI interfaces
 //! - Back up and restore prefixes
-//! 
+//!
 //! ## Usage
-//! 
+//!
 //! Run without arguments to launch the GUI:
-//! 
+//!
 //! ```
 //! proton-prefix-manager
 //! ```
-//! 
+//!
 //! Search for games by name:
-//! 
+//!
 //! ```
 //! proton-prefix-manager search "portal"
 //! ```
-//! 
+//!
 //! Find a prefix for a specific AppID:
-//! 
+//!
 //! ```
 //! proton-prefix-manager prefix 620
 //! ```
-//! 
+//!
 //! Open a prefix in your file manager:
-//! 
+//!
 //! ```
 //! proton-prefix-manager open 620
 //! ```
@@ -40,10 +40,10 @@ use clap::Parser;
 use eframe::NativeOptions;
 
 mod cli;
-mod gui;
-mod utils;
 mod core;
 mod error;
+mod gui;
+mod utils;
 
 #[cfg(test)]
 mod test_helpers;
@@ -58,22 +58,44 @@ fn main() {
     let cli = Cli::parse();
 
     match &cli.command {
-        Some(Commands::Search { name, json, plain, delimiter }) => {
+        Some(Commands::Search {
+            name,
+            json,
+            plain,
+            delimiter,
+        }) => {
             let format = determine_format(*json, *plain, delimiter);
             cli::search::execute(name, &format);
         }
-        Some(Commands::Prefix { appid, json, plain, delimiter }) => {
+        Some(Commands::Prefix {
+            appid,
+            json,
+            plain,
+            delimiter,
+        }) => {
             let format = determine_format(*json, *plain, delimiter);
             cli::prefix::execute(*appid, &format);
         }
         Some(Commands::Open { appid }) => {
             cli::open::execute(*appid);
         }
-        Some(Commands::Backup { appid, path }) => {
-            cli::backup::execute(*appid, path.clone());
+        Some(Commands::Backup { appid }) => {
+            cli::backup::execute(*appid);
         }
         Some(Commands::Restore { appid, path }) => {
             cli::restore::execute(*appid, path.clone());
+        }
+        Some(Commands::ListBackups { appid }) => {
+            cli::list_backups::execute(*appid);
+        }
+        Some(Commands::DeleteBackup { appid, backup }) => {
+            cli::delete_backup::execute(*appid, backup.clone());
+        }
+        Some(Commands::Reset { appid }) => {
+            cli::reset::execute(*appid);
+        }
+        Some(Commands::ClearCache { appid }) => {
+            cli::clear_cache::execute(*appid);
         }
         None => {
             log::info!("Launching GUI...");
@@ -82,7 +104,8 @@ fn main() {
                 "Proton Prefix Manager",
                 native_options,
                 Box::new(|_cc| Ok(Box::new(ProtonPrefixManagerApp::new()))),
-            ).expect("Failed to start GUI");
+            )
+            .expect("Failed to start GUI");
         }
     }
 }


### PR DESCRIPTION
## Summary
- store backups automatically with timestamp per app ID
- add CLI subcommands for listing, deleting, resetting and clearing shader cache
- add GUI buttons for backup/restore/delete/reset/clear cache
- document new commands

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684da27c14c08333acbcad8df67182c6