### PR TITLE
Add protontricks and winecfg CLI commands

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,8 +6,10 @@ pub mod clear_cache;
 pub mod delete_backup;
 pub mod list_backups;
 pub mod open;
+pub mod protontricks;
 pub mod prefix;
 pub mod reset;
+pub mod winecfg;
 pub mod restore;
 pub mod search;
 
@@ -103,6 +105,22 @@ pub enum Commands {
 
     /// Clear the shader cache for the given App ID
     ClearCache {
+        /// The Steam App ID of the game
+        appid: u32,
+    },
+
+    /// Run protontricks for the given App ID
+    Protontricks {
+        /// The Steam App ID of the game
+        appid: u32,
+
+        /// Additional arguments for protontricks
+        #[arg(trailing_var_arg = true)]
+        args: Vec<String>,
+    },
+
+    /// Launch winecfg for the given App ID
+    Winecfg {
         /// The Steam App ID of the game
         appid: u32,
     },

--- a/src/cli/protontricks.rs
+++ b/src/cli/protontricks.rs
@@ -1,0 +1,121 @@
+use crate::core::steam;
+
+#[cfg(test)]
+use once_cell::sync::Lazy;
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(not(test))]
+fn run_protontricks(appid: u32, args: &[String]) -> std::io::Result<()> {
+    let status = std::process::Command::new("protontricks")
+        .arg(appid.to_string())
+        .args(args)
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("protontricks exited with status {}", status),
+        ))
+    }
+}
+
+#[cfg(test)]
+pub static PROTONTRICKS_CALLS: Lazy<Mutex<Vec<(u32, Vec<String>)>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+#[cfg(test)]
+fn run_protontricks(appid: u32, args: &[String]) -> std::io::Result<()> {
+    PROTONTRICKS_CALLS
+        .lock()
+        .unwrap()
+        .push((appid, args.to_vec()));
+    Ok(())
+}
+
+pub fn execute(appid: u32, args: &[String]) {
+    println!("🔧 Running protontricks for AppID: {}", appid);
+
+    match steam::get_steam_libraries() {
+        Ok(libraries) => {
+            if steam::find_proton_prefix(appid, &libraries).is_some() {
+                if let Err(e) = run_protontricks(appid, args) {
+                    eprintln!("❌ Failed to run protontricks: {}", e);
+                }
+            } else {
+                println!("❌ Proton prefix not found for AppID: {}", appid);
+            }
+        }
+        Err(err) => {
+            eprintln!("❌ Error: {}", err);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::TEST_MUTEX;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn setup_mock_steam(appid: u32) -> (tempfile::TempDir, std::path::PathBuf) {
+        let home = tempdir().unwrap();
+        let config_dir = home.path().join(".steam/steam/config");
+        fs::create_dir_all(&config_dir).unwrap();
+
+        let library_dir = home.path().join("library");
+        let compat_path = library_dir
+            .join("steamapps/compatdata")
+            .join(appid.to_string());
+        fs::create_dir_all(&compat_path).unwrap();
+
+        let vdf_path = config_dir.join("libraryfolders.vdf");
+        let content = format!(
+            "\"libraryfolders\" {{\n    \"0\" {{\n        \"path\" \"{}\"\n    }}\n}}",
+            library_dir.display()
+        );
+        fs::write(&vdf_path, content).unwrap();
+
+        (home, compat_path)
+    }
+
+    #[test]
+    fn test_execute_runs_protontricks() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let appid = 1234;
+        let (home, _prefix) = setup_mock_steam(appid);
+        let old_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", home.path()); }
+
+        PROTONTRICKS_CALLS.lock().unwrap().clear();
+        execute(appid, &["-v".to_string()]);
+
+        let calls = PROTONTRICKS_CALLS.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, appid);
+        assert_eq!(calls[0].1, vec!["-v".to_string()]);
+
+        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+    }
+
+    #[test]
+    fn test_execute_no_prefix() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let appid = 5678;
+        let (home, prefix) = setup_mock_steam(appid);
+        fs::remove_dir_all(&prefix).unwrap();
+        let old_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", home.path()); }
+
+        PROTONTRICKS_CALLS.lock().unwrap().clear();
+        execute(appid, &[]);
+
+        let calls = PROTONTRICKS_CALLS.lock().unwrap();
+        assert!(calls.is_empty());
+
+        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+    }
+}

--- a/src/cli/winecfg.rs
+++ b/src/cli/winecfg.rs
@@ -1,0 +1,112 @@
+use crate::core::steam;
+
+#[cfg(test)]
+use once_cell::sync::Lazy;
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(not(test))]
+fn run_winecfg(prefix_path: &std::path::Path) -> std::io::Result<()> {
+    std::process::Command::new("winecfg")
+        .env("WINEPREFIX", prefix_path)
+        .spawn()
+        .map(|_| ())
+}
+
+#[cfg(test)]
+pub static WINECFG_CALLS: Lazy<Mutex<Vec<std::path::PathBuf>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+#[cfg(test)]
+fn run_winecfg(prefix_path: &std::path::Path) -> std::io::Result<()> {
+    WINECFG_CALLS
+        .lock()
+        .unwrap()
+        .push(prefix_path.to_path_buf());
+    Ok(())
+}
+
+pub fn execute(appid: u32) {
+    println!("🍷 Launching winecfg for AppID: {}", appid);
+
+    match steam::get_steam_libraries() {
+        Ok(libraries) => {
+            if let Some(prefix_path) = steam::find_proton_prefix(appid, &libraries) {
+                if let Err(e) = run_winecfg(&prefix_path) {
+                    eprintln!("❌ Failed to launch winecfg: {}", e);
+                }
+            } else {
+                println!("❌ Proton prefix not found for AppID: {}", appid);
+            }
+        }
+        Err(err) => {
+            eprintln!("❌ Error: {}", err);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::TEST_MUTEX;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn setup_mock_steam(appid: u32) -> (tempfile::TempDir, std::path::PathBuf) {
+        let home = tempdir().unwrap();
+        let config_dir = home.path().join(".steam/steam/config");
+        fs::create_dir_all(&config_dir).unwrap();
+
+        let library_dir = home.path().join("library");
+        let compat_path = library_dir
+            .join("steamapps/compatdata")
+            .join(appid.to_string());
+        fs::create_dir_all(&compat_path).unwrap();
+
+        let vdf_path = config_dir.join("libraryfolders.vdf");
+        let content = format!(
+            "\"libraryfolders\" {{\n    \"0\" {{\n        \"path\" \"{}\"\n    }}\n}}",
+            library_dir.display()
+        );
+        fs::write(&vdf_path, content).unwrap();
+
+        (home, compat_path)
+    }
+
+    #[test]
+    fn test_execute_runs_winecfg() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let appid = 4321;
+        let (home, prefix) = setup_mock_steam(appid);
+        let old_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", home.path()); }
+
+        WINECFG_CALLS.lock().unwrap().clear();
+        execute(appid);
+
+        let calls = WINECFG_CALLS.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], prefix);
+
+        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+    }
+
+    #[test]
+    fn test_execute_no_prefix() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let appid = 8765;
+        let (home, prefix) = setup_mock_steam(appid);
+        fs::remove_dir_all(&prefix).unwrap();
+        let old_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", home.path()); }
+
+        WINECFG_CALLS.lock().unwrap().clear();
+        execute(appid);
+
+        let calls = WINECFG_CALLS.lock().unwrap();
+        assert!(calls.is_empty());
+
+        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,12 @@ fn main() {
         Some(Commands::ClearCache { appid }) => {
             cli::clear_cache::execute(*appid);
         }
+        Some(Commands::Protontricks { appid, args }) => {
+            cli::protontricks::execute(*appid, args);
+        }
+        Some(Commands::Winecfg { appid }) => {
+            cli::winecfg::execute(*appid);
+        }
         None => {
             log::info!("Launching GUI...");
             let native_options = NativeOptions::default();


### PR DESCRIPTION
## Summary
- expose new subcommands `protontricks` and `winecfg`
- implement command handlers for running protontricks and winecfg
- wire new commands into main CLI
- add unit tests for new functionality

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f4b84968c833399853e29cffa9506