### PR TITLE
Add protontricks and winecfg buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Run the program without arguments to launch the GUI:
 proton-prefix-manager
 ```
 
-The GUI lists your installed Steam games and shows details about each prefix. You can copy or open the prefix path and follow external links such as SteamDB or ProtonDB.
+The GUI lists your installed Steam games and shows details about each prefix. You can copy or open the prefix path, run Protontricks or launch `winecfg` for the selected game, and follow external links such as SteamDB or ProtonDB.
 
 ### Command line interface
 
@@ -89,6 +89,18 @@ Clear shader cache:
 
 ```bash
 proton-prefix-manager clear-cache 620
+```
+
+Run protontricks:
+
+```bash
+proton-prefix-manager protontricks 620
+```
+
+Launch winecfg:
+
+```bash
+proton-prefix-manager winecfg 620
 ```
 
 The CLI supports JSON (`--json`), plain text (`--plain`), and custom-delimited output using `--delimiter`.

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -2,6 +2,8 @@ use crate::core::models::GameInfo;
 use crate::core::steam;
 use crate::utils::backup as backup_utils;
 use eframe::egui;
+use std::thread;
+use crate::cli::{protontricks, winecfg};
 use std::fs;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -259,6 +261,20 @@ impl<'a> GameDetails<'a> {
                                         ),
                                     }
                                 }
+                            }
+
+                            if ui.button("🔧 Protontricks").clicked() {
+                                let appid = game.app_id();
+                                thread::spawn(move || {
+                                    protontricks::execute(appid, &[]);
+                                });
+                            }
+
+                            if ui.button("⚙️ winecfg").clicked() {
+                                let appid = game.app_id();
+                                thread::spawn(move || {
+                                    winecfg::execute(appid);
+                                });
                             }
                         }
 


### PR DESCRIPTION
## Summary
- add Protontricks and winecfg actions to prefix details screen
- document new GUI functionality in README
- document protontricks and winecfg CLI commands

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f53912a308333a62ba293d3634f72