### PR TITLE
Add dependency checks for external tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,6 +2593,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tinyfiledialogs",
+ "which",
 ]
 
 [[package]]
@@ -3665,6 +3666,18 @@ dependencies = [
  "js-sys",
  "log",
  "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ env_logger = "0.10"
 thiserror = "1.0.57"
 anyhow = "1.0.80"
 rayon = "1.8.0"
+which = "4.4.2"
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/src/cli/protontricks.rs
+++ b/src/cli/protontricks.rs
@@ -1,4 +1,5 @@
 use crate::core::steam;
+use crate::utils::dependencies::command_available;
 
 #[cfg(test)]
 use once_cell::sync::Lazy;
@@ -35,6 +36,11 @@ fn run_protontricks(appid: u32, args: &[String]) -> std::io::Result<()> {
 
 pub fn execute(appid: u32, args: &[String]) {
     println!("🔧 Running protontricks for AppID: {}", appid);
+
+    if !command_available("protontricks") {
+        eprintln!("❌ 'protontricks' is not installed or not found in PATH. Please install it to use this feature.");
+        return;
+    }
 
     match steam::get_steam_libraries() {
         Ok(libraries) => {

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -5,6 +5,8 @@ use crate::core::steam;
 use eframe::egui;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::collections::BTreeMap;
+use crate::utils::dependencies::scan_tools;
 
 pub struct ProtonPrefixManagerApp {
     loading: bool,
@@ -18,6 +20,8 @@ pub struct ProtonPrefixManagerApp {
     dark_mode: bool,
     restore_dialog_open: bool,
     delete_dialog_open: bool,
+    about_open: bool,
+    tool_status: BTreeMap<String, bool>,
 }
 
 impl Default for ProtonPrefixManagerApp {
@@ -34,6 +38,8 @@ impl Default for ProtonPrefixManagerApp {
             dark_mode: true,
             restore_dialog_open: false,
             delete_dialog_open: false,
+            about_open: false,
+            tool_status: scan_tools(&["protontricks", "winecfg"]),
         }
     }
 }
@@ -232,6 +238,9 @@ impl eframe::App for ProtonPrefixManagerApp {
                         "GitHub",
                         "https://github.com/yourusername/proton-prefix-manager",
                     );
+                    if ui.button("About").clicked() {
+                        self.about_open = true;
+                    }
                 });
             });
         });
@@ -267,9 +276,23 @@ impl eframe::App for ProtonPrefixManagerApp {
                             ui,
                             &mut self.restore_dialog_open,
                             &mut self.delete_dialog_open,
+                            &self.tool_status,
                         );
                     });
             });
         });
+
+        if self.about_open {
+            egui::Window::new("About")
+                .open(&mut self.about_open)
+                .resizable(false)
+                .show(ctx, |ui| {
+                    ui.heading("External Tools");
+                    for (tool, available) in &self.tool_status {
+                        let status = if *available { "✓" } else { "Missing" };
+                        ui.label(format!("{}: {}", tool, status));
+                    }
+                });
+        }
     }
 }

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -4,6 +4,7 @@ use crate::utils::backup as backup_utils;
 use eframe::egui;
 use std::thread;
 use crate::cli::{protontricks, winecfg};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -175,6 +176,7 @@ impl<'a> GameDetails<'a> {
         ui: &mut egui::Ui,
         restore_dialog_open: &mut bool,
         delete_dialog_open: &mut bool,
+        tools: &BTreeMap<String, bool>,
     ) {
         if let Some(game) = self.game {
             // Game title and AppID in a header section
@@ -263,18 +265,32 @@ impl<'a> GameDetails<'a> {
                                 }
                             }
 
-                            if ui.button("🔧 Protontricks").clicked() {
+                            let protontricks_btn = ui.add_enabled(
+                                *tools.get("protontricks").unwrap_or(&false),
+                                egui::Button::new("🔧 Protontricks"),
+                            );
+                            if protontricks_btn.clicked() {
                                 let appid = game.app_id();
                                 thread::spawn(move || {
                                     protontricks::execute(appid, &[]);
                                 });
                             }
+                            if !tools.get("protontricks").unwrap_or(&false) {
+                                protontricks_btn.on_hover_text("protontricks not found");
+                            }
 
-                            if ui.button("⚙️ winecfg").clicked() {
+                            let winecfg_btn = ui.add_enabled(
+                                *tools.get("winecfg").unwrap_or(&false),
+                                egui::Button::new("⚙️ winecfg"),
+                            );
+                            if winecfg_btn.clicked() {
                                 let appid = game.app_id();
                                 thread::spawn(move || {
                                     winecfg::execute(appid);
                                 });
+                            }
+                            if !tools.get("winecfg").unwrap_or(&false) {
+                                winecfg_btn.on_hover_text("winecfg not found");
                             }
                         }
 

--- a/src/utils/dependencies.rs
+++ b/src/utils/dependencies.rs
@@ -1,0 +1,30 @@
+use std::collections::BTreeMap;
+
+#[cfg(not(test))]
+use which::which;
+
+#[cfg(not(test))]
+pub fn command_available(command: &str) -> bool {
+    which(command).is_ok()
+}
+
+#[cfg(test)]
+pub fn command_available(_command: &str) -> bool {
+    true
+}
+
+#[cfg(not(test))]
+pub fn scan_tools(tools: &[&str]) -> BTreeMap<String, bool> {
+    tools
+        .iter()
+        .map(|t| ((*t).to_string(), command_available(t)))
+        .collect()
+}
+
+#[cfg(test)]
+pub fn scan_tools(tools: &[&str]) -> BTreeMap<String, bool> {
+    tools
+        .iter()
+        .map(|t| ((*t).to_string(), true))
+        .collect()
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,3 +2,4 @@
 pub mod backup;
 pub mod library;
 pub mod output;
+pub mod dependencies;


### PR DESCRIPTION
## Summary
- check for `protontricks` and `winecfg` binaries before launch
- centralize tool availability helpers
- disable GUI buttons when tools are missing and add an About dialog listing tool status

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f5509da908333bb2e60cc6ec8b9c5