### PR TITLE
Add tooltips for missing dependencies

### DIFF
--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -276,7 +276,9 @@ impl<'a> GameDetails<'a> {
                                 });
                             }
                             if !tools.get("protontricks").unwrap_or(&false) {
-                                protontricks_btn.on_hover_text("protontricks not found");
+                                protontricks_btn.on_hover_text(
+                                    "Install `protontricks` to enable this feature.",
+                                );
                             }
 
                             let winecfg_btn = ui.add_enabled(
@@ -290,7 +292,9 @@ impl<'a> GameDetails<'a> {
                                 });
                             }
                             if !tools.get("winecfg").unwrap_or(&false) {
-                                winecfg_btn.on_hover_text("winecfg not found");
+                                winecfg_btn.on_hover_text(
+                                    "Install `winecfg` to enable this feature.",
+                                );
                             }
                         }
 


### PR DESCRIPTION
## Summary
- show tooltip when protontricks or winecfg is missing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f59fc7ac48333aeda328cb6c4c6dc