### PR TITLE
Improve dependency feedback

### DIFF
--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -277,7 +277,7 @@ impl<'a> GameDetails<'a> {
                             }
                             if !tools.get("protontricks").unwrap_or(&false) {
                                 protontricks_btn.on_hover_text(
-                                    "Install `protontricks` to enable this feature.",
+                                    "This feature requires `protontricks`. Please install it using your package manager.",
                                 );
                             }
 
@@ -293,7 +293,7 @@ impl<'a> GameDetails<'a> {
                             }
                             if !tools.get("winecfg").unwrap_or(&false) {
                                 winecfg_btn.on_hover_text(
-                                    "Install `winecfg` to enable this feature.",
+                                    "`winecfg` is not installed or not found in PATH. Please install Wine.",
                                 );
                             }
                         }


### PR DESCRIPTION
## Summary
- remove About button and dialog
- rescan for external tools periodically
- show detailed tooltips on missing Protontricks or Winecfg

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f5cc92e5c8333b0944e6c72b71f0a