### PR TITLE
Add game config editor feature

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,0 +1,56 @@
+use crate::core::steam;
+use crate::utils::manifest as manifest_utils;
+use std::fs;
+
+pub fn execute(
+    appid: u32,
+    launch: Option<String>,
+    proton: Option<String>,
+    cloud: Option<bool>,
+    auto_update: Option<String>,
+) {
+    if launch.is_none() && proton.is_none() && cloud.is_none() && auto_update.is_none() {
+        println!("No configuration changes specified.");
+        return;
+    }
+
+    match steam::get_steam_libraries() {
+        Ok(libraries) => {
+            for lib in libraries {
+                let manifest = lib
+                    .steamapps_path()
+                    .join(format!("appmanifest_{}.acf", appid));
+                if manifest.exists() {
+                    match fs::read_to_string(&manifest) {
+                        Ok(mut contents) => {
+                            if let Some(v) = launch {
+                                contents = manifest_utils::update_or_insert(&contents, "LaunchOptions", &v);
+                            }
+                            if let Some(v) = proton {
+                                contents = manifest_utils::update_or_insert(&contents, "CompatToolOverride", &v);
+                            }
+                            if let Some(v) = cloud {
+                                let val = if v { "1" } else { "0" };
+                                contents = manifest_utils::update_or_insert(&contents, "AllowCloudSaves", val);
+                            }
+                            if let Some(v) = auto_update {
+                                contents = manifest_utils::update_or_insert(&contents, "AutoUpdateBehavior", &v);
+                            }
+                            if let Err(e) = fs::write(&manifest, contents) {
+                                eprintln!("Failed to write manifest: {}", e);
+                            } else {
+                                println!("Updated {}", manifest.display());
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to read manifest {}: {}", manifest.display(), e);
+                        }
+                    }
+                    return;
+                }
+            }
+            println!("Manifest not found for {}", appid);
+        }
+        Err(e) => eprintln!("❌ Error: {}", e),
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,7 @@ pub mod reset;
 pub mod winecfg;
 pub mod restore;
 pub mod search;
+pub mod config;
 
 /// Proton Prefix Manager CLI
 ///
@@ -123,5 +124,27 @@ pub enum Commands {
     Winecfg {
         /// The Steam App ID of the game
         appid: u32,
+    },
+
+    /// Edit game configuration in the manifest
+    Config {
+        /// The Steam App ID of the game
+        appid: u32,
+
+        /// Set custom launch options
+        #[arg(long)]
+        launch: Option<String>,
+
+        /// Force a specific Proton version
+        #[arg(long)]
+        proton: Option<String>,
+
+        /// Enable or disable Steam Cloud
+        #[arg(long)]
+        cloud: Option<bool>,
+
+        /// Auto update behavior
+        #[arg(long)]
+        auto_update: Option<String>,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,21 @@ fn main() {
         Some(Commands::Winecfg { appid }) => {
             cli::winecfg::execute(*appid);
         }
+        Some(Commands::Config {
+            appid,
+            launch,
+            proton,
+            cloud,
+            auto_update,
+        }) => {
+            cli::config::execute(
+                *appid,
+                launch.clone(),
+                proton.clone(),
+                *cloud,
+                auto_update.clone(),
+            );
+        }
         None => {
             log::info!("Launching GUI...");
             let native_options = NativeOptions::default();

--- a/src/utils/manifest.rs
+++ b/src/utils/manifest.rs
@@ -1,0 +1,23 @@
+use regex::Regex;
+
+/// Update or insert a key-value pair in a Steam appmanifest file.
+///
+/// The function searches for `key` and replaces its value if found. If the key
+/// does not exist, it is inserted before the final closing brace.
+pub fn update_or_insert(contents: &str, key: &str, value: &str) -> String {
+    let re = Regex::new(&format!(r#"\"{}\"\s+\"([^\"]*)\""#, regex::escape(key))).unwrap();
+    if re.is_match(contents) {
+        re.replace_all(contents, format!("\"{}\" \"{}\"", key, value)).into_owned()
+    } else {
+        if let Some(pos) = contents.rfind('}') {
+            let (head, tail) = contents.split_at(pos);
+            let mut new_contents = String::new();
+            new_contents.push_str(head);
+            new_contents.push_str(&format!("    \"{}\" \"{}\"\n", key, value));
+            new_contents.push_str(tail);
+            new_contents
+        } else {
+            contents.to_string()
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,3 +3,4 @@ pub mod backup;
 pub mod library;
 pub mod output;
 pub mod dependencies;
+pub mod manifest;


### PR DESCRIPTION
## Summary
- add manifest editing helper
- support editing launch options, proton version, cloud sync, and auto update via CLI `config` command
- wire new command into the app

## Testing
- `cargo test --quiet`
- `cargo fmt` *(fails: component unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684f5f2356dc83338783eb417c2333f2