### PR TITLE
Handle missing prefixes in UI

### DIFF
--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -191,29 +191,35 @@ impl<'a> GameDetails<'a> {
             egui::CollapsingHeader::new("Prefix Information")
                 .default_open(true)
                 .show(ui, |ui| {
-                    self.show_path(ui, "Prefix Path:", game.prefix_path());
+                    if self.prefix_available() {
+                        self.show_path(ui, "Prefix Path:", game.prefix_path());
 
-                    if let Ok(metadata) = fs::metadata(game.prefix_path()) {
-                        if let Ok(modified) = metadata.modified() {
-                            if let Ok(time) = modified.duration_since(UNIX_EPOCH) {
-                                let datetime = chrono::DateTime::<chrono::Local>::from(
-                                    SystemTime::UNIX_EPOCH + time,
-                                );
-                                egui::Grid::new("modified_time")
-                                    .num_columns(2)
-                                    .spacing([8.0, 4.0])
-                                    .show(ui, |ui| {
-                                        ui.label("Last Modified:");
-                                        ui.monospace(datetime.format("%Y-%m-%d %H:%M").to_string());
-                                        ui.end_row();
-                                    });
+                        if let Ok(metadata) = fs::metadata(game.prefix_path()) {
+                            if let Ok(modified) = metadata.modified() {
+                                if let Ok(time) = modified.duration_since(UNIX_EPOCH) {
+                                    let datetime = chrono::DateTime::<chrono::Local>::from(
+                                        SystemTime::UNIX_EPOCH + time,
+                                    );
+                                    egui::Grid::new("modified_time")
+                                        .num_columns(2)
+                                        .spacing([8.0, 4.0])
+                                        .show(ui, |ui| {
+                                            ui.label("Last Modified:");
+                                            ui.monospace(
+                                                datetime.format("%Y-%m-%d %H:%M").to_string(),
+                                            );
+                                            ui.end_row();
+                                        });
+                                }
                             }
                         }
-                    }
 
-                    let drive_c = game.prefix_path().join("pfx/drive_c");
-                    if drive_c.exists() {
-                        self.show_path(ui, "Drive C:", &drive_c);
+                        let drive_c = game.prefix_path().join("pfx/drive_c");
+                        if drive_c.exists() {
+                            self.show_path(ui, "Drive C:", &drive_c);
+                        }
+                    } else {
+                        ui.label("No prefix currently exists for this game.");
                     }
 
                     ui.horizontal(|ui| {


### PR DESCRIPTION
## Summary
- check if a game prefix directory actually exists before showing it
- display a message when no prefix is found

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f5fdb6a3483339c421edd4a765fb3