### PR TITLE
Add GUI game settings editor

### DIFF
--- a/src/utils/manifest.rs
+++ b/src/utils/manifest.rs
@@ -21,3 +21,10 @@ pub fn update_or_insert(contents: &str, key: &str, value: &str) -> String {
         }
     }
 }
+
+/// Retrieve the value for a key from a Steam appmanifest file contents.
+pub fn get_value(contents: &str, key: &str) -> Option<String> {
+    let re = Regex::new(&format!(r#"\"{}\"\s+\"([^\"]*)\""#, regex::escape(key))).ok()?;
+    re.captures(contents)
+        .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
+}


### PR DESCRIPTION
## Summary
- add a new `GameConfig` struct and helper functions for reading/writing appmanifest values
- show a new **Game Settings** section in the game details panel
- list available Proton versions and allow editing launch options, cloud sync and auto‑update
- expose helper `get_value` in `manifest` utilities

## Testing
- `cargo test --no-run`
- `cargo test` *(all tests passed)*
- ❌ `rustup component add rustfmt` (blocked)

------
https://chatgpt.com/codex/tasks/task_e_684f658cfe9c8333bd498c0a4b27e290