### PR TITLE
Add open terminal feature

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::collections::BTreeMap;
 use crate::utils::dependencies::scan_tools;
+use crate::utils::terminal;
 
 pub struct ProtonPrefixManagerApp {
     loading: bool,
@@ -38,7 +39,11 @@ impl Default for ProtonPrefixManagerApp {
             dark_mode: true,
             restore_dialog_open: false,
             delete_dialog_open: false,
-            tool_status: scan_tools(&["protontricks", "winecfg"]),
+            tool_status: {
+                let mut map = scan_tools(&["protontricks", "winecfg"]);
+                map.insert("terminal".to_string(), terminal::terminal_available());
+                map
+            },
             last_tool_scan: 0.0,
         }
     }
@@ -283,6 +288,7 @@ impl eframe::App for ProtonPrefixManagerApp {
         let now = ctx.input(|i| i.time);
         if now - self.last_tool_scan > 5.0 {
             self.tool_status = scan_tools(&["protontricks", "winecfg"]);
+            self.tool_status.insert("terminal".to_string(), terminal::terminal_available());
             self.last_tool_scan = now;
         }
     }

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -4,6 +4,7 @@ use crate::utils::backup as backup_utils;
 use eframe::egui;
 use std::thread;
 use crate::cli::{protontricks, winecfg};
+use crate::utils::terminal;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
@@ -300,6 +301,28 @@ impl<'a> GameDetails<'a> {
                             if !tools.get("winecfg").unwrap_or(&false) {
                                 winecfg_btn.on_hover_text(
                                     "`winecfg` is not installed or not found in PATH. Please install Wine.",
+                                );
+                            }
+
+                            let terminal_btn = ui.add_enabled(
+                                *tools.get("terminal").unwrap_or(&false),
+                                egui::Button::new("🖥 Open Terminal"),
+                            );
+                            if terminal_btn.clicked() {
+                                let path = game.prefix_path().to_path_buf();
+                                thread::spawn(move || {
+                                    if let Err(e) = terminal::open_terminal(&path) {
+                                        eprintln!("Failed to open terminal: {}", e);
+                                    }
+                                });
+                            }
+                            if *tools.get("terminal").unwrap_or(&false) {
+                                terminal_btn.on_hover_text(
+                                    "Opens a terminal with WINEPREFIX set to this game's prefix.",
+                                );
+                            } else {
+                                terminal_btn.on_hover_text(
+                                    "No terminal emulator found on system.",
                                 );
                             }
                         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,3 +4,4 @@ pub mod library;
 pub mod output;
 pub mod dependencies;
 pub mod manifest;
+pub mod terminal;

--- a/src/utils/terminal.rs
+++ b/src/utils/terminal.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+use std::process::Command;
+
+use super::dependencies::command_available;
+
+/// Find a usable terminal emulator command.
+///
+/// Checks the `TERMINAL` environment variable first, then some common
+/// terminal emulators.
+pub fn find_terminal() -> Option<String> {
+    if let Ok(term) = std::env::var("TERMINAL") {
+        if command_available(&term) {
+            return Some(term);
+        }
+    }
+
+    for cmd in ["x-terminal-emulator", "gnome-terminal", "konsole", "xterm"] {
+        if command_available(cmd) {
+            return Some(cmd.to_string());
+        }
+    }
+
+    None
+}
+
+/// Check if any terminal emulator is available.
+pub fn terminal_available() -> bool {
+    find_terminal().is_some()
+}
+
+/// Launch a terminal with `WINEPREFIX` and working directory set to `path`.
+pub fn open_terminal(path: &Path) -> std::io::Result<()> {
+    let term = find_terminal()
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "No terminal emulator found"))?;
+
+    Command::new(term)
+        .env("WINEPREFIX", path)
+        .current_dir(path)
+        .spawn()
+        .map(|_| ())
+}


### PR DESCRIPTION
## Summary
- create a utility for launching a terminal in the prefix directory
- show new "Open Terminal" button in prefix details
- track presence of terminal emulators in the GUI state

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f65f72fb48333bc1c8ce91912fe3b