### PR TITLE
Fix launch options TextEdit

### DIFF
--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -495,6 +495,7 @@ impl<'a> GameDetails<'a> {
                         ui.label("Launch Options:");
                         ui.add(
                             egui::TextEdit::singleline(&mut cfg.launch_options)
+                                .id_source("launch_options")
                                 .hint_text("e.g. PROTON_LOG=1"),
                         );
                     });


### PR DESCRIPTION
## Summary
- ensure egui TextEdit for launch options keeps focus

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68509a1073d08333807e52b970e2138a