### PR TITLE
Load launch options from user config

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,5 +1,6 @@
 use crate::core::steam;
 use crate::utils::manifest as manifest_utils;
+use crate::utils::user_config;
 use std::fs;
 
 pub fn execute(
@@ -25,6 +26,7 @@ pub fn execute(
                         Ok(mut contents) => {
                             if let Some(v) = launch {
                                 contents = manifest_utils::update_or_insert(&contents, "LaunchOptions", &v);
+                                let _ = user_config::set_launch_options(appid, &v);
                             }
                             if let Some(v) = proton {
                                 contents = manifest_utils::update_or_insert(&contents, "CompatToolOverride", &v);

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::io;
 use crate::utils::manifest as manifest_utils;
+use crate::utils::user_config;
 use tinyfiledialogs as tfd;
 use chrono::NaiveDateTime;
 use egui::menu;
@@ -223,7 +224,9 @@ impl<'a> GameDetails<'a> {
             if manifest.exists() {
                 let contents = fs::read_to_string(&manifest)?;
                 let proton = manifest_utils::get_value(&contents, "CompatToolOverride");
-                let launch = manifest_utils::get_value(&contents, "LaunchOptions").unwrap_or_default();
+                let launch = user_config::get_launch_options(app_id)
+                    .or_else(|| manifest_utils::get_value(&contents, "LaunchOptions"))
+                    .unwrap_or_default();
                 let cloud = manifest_utils::get_value(&contents, "AllowCloudSaves").unwrap_or_else(|| "1".to_string()) == "1";
                 let auto = manifest_utils::get_value(&contents, "AutoUpdateBehavior").unwrap_or_else(|| "0".to_string()) == "0";
                 return Ok(GameConfig {
@@ -247,6 +250,7 @@ impl<'a> GameDetails<'a> {
             if manifest.exists() {
                 let mut contents = fs::read_to_string(&manifest)?;
                 contents = manifest_utils::update_or_insert(&contents, "LaunchOptions", &cfg.launch_options);
+                let _ = user_config::set_launch_options(app_id, &cfg.launch_options);
                 if let Some(p) = &cfg.proton {
                     contents = manifest_utils::update_or_insert(&contents, "CompatToolOverride", p);
                 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,4 +4,5 @@ pub mod library;
 pub mod output;
 pub mod dependencies;
 pub mod manifest;
+pub mod user_config;
 pub mod terminal;

--- a/src/utils/user_config.rs
+++ b/src/utils/user_config.rs
@@ -1,0 +1,76 @@
+use regex::Regex;
+use std::{fs, io, path::{PathBuf}};
+use dirs_next;
+
+/// Search Steam userdata directories for localconfig.vdf files.
+fn userdata_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(home) = dirs_next::home_dir() {
+        let p1 = home.join(".steam/steam/userdata");
+        if p1.exists() { dirs.push(p1); }
+        let p2 = home.join(".local/share/Steam/userdata");
+        if p2.exists() { dirs.push(p2); }
+    }
+    dirs
+}
+
+fn find_localconfig_files() -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for dir in userdata_dirs() {
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let cfg = entry.path().join("config/localconfig.vdf");
+                if cfg.exists() { files.push(cfg); }
+            }
+        }
+    }
+    files
+}
+
+fn parse_launch_options(contents: &str, app_id: u32) -> Option<String> {
+    let pattern = format!(r#"(?s)\"{}\"\s*\{{[^}}]*\"LaunchOptions\"\s+\"([^\"]*)\""#, app_id);
+    let re = Regex::new(&pattern).ok()?;
+    re.captures(contents)
+        .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
+}
+
+pub fn get_launch_options(app_id: u32) -> Option<String> {
+    for cfg in find_localconfig_files() {
+        if let Ok(contents) = fs::read_to_string(&cfg) {
+            if let Some(val) = parse_launch_options(&contents, app_id) {
+                return Some(val);
+            }
+        }
+    }
+    None
+}
+
+fn update_launch_options(contents: &str, app_id: u32, value: &str) -> Option<String> {
+    let pattern = format!(r#"(?s)(\"{}\"\s*\{{)([^}}]*)(\}})"#, app_id);
+    let re = Regex::new(&pattern).ok()?;
+    if let Some(cap) = re.captures(contents) {
+        let start = cap.get(1)?.as_str();
+        let body = cap.get(2)?.as_str();
+        let end = cap.get(3)?.as_str();
+        let updated_body = crate::utils::manifest::update_or_insert(body, "LaunchOptions", value);
+        let mut new_section = String::new();
+        new_section.push_str(start);
+        new_section.push_str(&updated_body);
+        new_section.push_str(end);
+        Some(re.replace(contents, new_section).into_owned())
+    } else {
+        None
+    }
+}
+
+pub fn set_launch_options(app_id: u32, value: &str) -> io::Result<()> {
+    for cfg in find_localconfig_files() {
+        if let Ok(contents) = fs::read_to_string(&cfg) {
+            if let Some(updated) = update_launch_options(&contents, app_id, value) {
+                fs::write(&cfg, updated)?;
+                return Ok(());
+            }
+        }
+    }
+    Err(io::Error::new(io::ErrorKind::NotFound, "localconfig not found"))
+}


### PR DESCRIPTION
## Summary
- add user_config module to parse Steam's localconfig.vdf
- read launch options from localconfig in Game Details
- save launch options back to localconfig when updating settings
- update CLI config command to write launch options to user config

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68509eda96f0833392ff0444121ca48b