### PR TITLE
Implement Backup Explorer UI

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use crate::utils::dependencies::scan_tools;
 use crate::utils::terminal;
 use super::details::GameConfig;
+use super::backup_manager::BackupManagerWindow;
 
 pub struct ProtonPrefixManagerApp {
     loading: bool,
@@ -26,6 +27,8 @@ pub struct ProtonPrefixManagerApp {
     tool_status: BTreeMap<String, bool>,
     last_tool_scan: f64,
     config_cache: HashMap<u32, GameConfig>,
+    show_backup_manager: bool,
+    backup_manager: BackupManagerWindow,
 }
 
 impl Default for ProtonPrefixManagerApp {
@@ -49,6 +52,8 @@ impl Default for ProtonPrefixManagerApp {
             },
             last_tool_scan: 0.0,
             config_cache: HashMap::new(),
+            show_backup_manager: false,
+            backup_manager: BackupManagerWindow::new(),
         }
     }
 }
@@ -199,6 +204,9 @@ impl eframe::App for ProtonPrefixManagerApp {
                     if ui.button(if self.dark_mode { "☀" } else { "🌙" }).clicked() {
                         self.toggle_theme(ctx);
                     }
+                    if ui.button("Manage Backups").on_hover_text("View and manage backups for all games.").clicked() {
+                        self.show_backup_manager = true;
+                    }
                 });
             });
 
@@ -288,6 +296,14 @@ impl eframe::App for ProtonPrefixManagerApp {
                     });
             });
         });
+
+        if let Ok(games) = self.installed_games.lock() {
+            self.backup_manager
+                .show(ctx, &mut self.show_backup_manager, Some(&games));
+        } else {
+            self.backup_manager
+                .show(ctx, &mut self.show_backup_manager, None);
+        }
 
         // Periodically rescan for external tools so disabled buttons can update
         let now = ctx.input(|i| i.time);

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -13,7 +13,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::io;
 use crate::utils::manifest as manifest_utils;
 use tinyfiledialogs as tfd;
-use chrono::NaiveDateTime;
 use egui::menu;
 
 pub struct GameDetails<'a> {
@@ -202,16 +201,6 @@ impl<'a> GameDetails<'a> {
         false
     }
 
-    fn format_backup_name(path: &Path) -> String {
-        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-            if let Ok(dt) = NaiveDateTime::parse_from_str(name, "%Y%m%d%H%M%S") {
-                return dt.format("%Y-%m-%d %H:%M:%S").to_string();
-            }
-            name.to_string()
-        } else {
-            path.display().to_string()
-        }
-    }
 
     fn load_game_config(app_id: u32) -> io::Result<GameConfig> {
         let libraries = steam::get_steam_libraries()
@@ -296,7 +285,7 @@ impl<'a> GameDetails<'a> {
                     ui.label("No backups found");
                 } else {
                     for backup in backups {
-                        let label = Self::format_backup_name(&backup);
+                        let label = backup_utils::format_backup_name(&backup);
                         if ui.button(label).clicked() {
                             match backup_utils::restore_prefix(&backup, game.prefix_path()) {
                                 Ok(_) => tfd::message_box_ok(
@@ -334,7 +323,7 @@ impl<'a> GameDetails<'a> {
                     ui.label("No backups found");
                 } else {
                     for backup in backups {
-                        let label = Self::format_backup_name(&backup);
+                        let label = backup_utils::format_backup_name(&backup);
                         if ui.button(label).clicked() {
                             match backup_utils::delete_backup(&backup) {
                                 Ok(_) => tfd::message_box_ok(

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,5 +1,6 @@
 mod app;
 mod game_list;
 mod details;
+mod backup_manager;
 
 pub use app::ProtonPrefixManagerApp;


### PR DESCRIPTION
## Summary
- add `BackupManagerWindow` for exploring backups
- integrate backup management window into app GUI
- unify backup timestamp formatting logic
- expose global list of backups across games
- hook up button in toolbar for launching the backup manager

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68509fdd514c8333b5623d1b42b5eed7