### PR TITLE
Handle multi-user login config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Proton Prefix Manager is a tool for locating and exploring the Proton prefixes c
 
 Steam uses Proton prefixes (Wine environments) to run Windows games on Linux. This project helps you discover where those prefixes are stored so you can inspect or manage them. You can search your installed games, locate the prefix for a specific game, and open it in your file manager. When run without any arguments, the application launches a GUI that lists your games and shows prefix details.
 
+When multiple Steam users exist, Proton Prefix Manager checks `loginusers.vdf` under Steam's `config` directory and uses the account marked with `"MostRecent" "1"`. Launch options are read from and written to that user's `localconfig.vdf`.
+
 ## Installation
 
 1. Install [Rust](https://www.rust-lang.org/tools/install) and `cargo`.

--- a/src/utils/user_config.rs
+++ b/src/utils/user_config.rs
@@ -1,5 +1,7 @@
 use regex::Regex;
-use std::{fs, io, path::{PathBuf}};
+use std::fs;
+use std::io;
+use std::path::PathBuf;
 use dirs_next;
 
 /// Search Steam userdata directories for localconfig.vdf files.
@@ -14,13 +16,41 @@ fn userdata_dirs() -> Vec<PathBuf> {
     dirs
 }
 
+fn most_recent_user_id() -> Option<String> {
+    if let Some(home) = dirs_next::home_dir() {
+        let paths = [
+            home.join(".steam/steam/config/loginusers.vdf"),
+            home.join(".local/share/Steam/config/loginusers.vdf"),
+        ];
+        let re = Regex::new(r#"(?s)"(\d+)"\s*\{[^}]*"MostRecent"\s*"1""#).ok()?;
+        for p in paths.iter() {
+            if p.exists() {
+                if let Ok(contents) = fs::read_to_string(p) {
+                    if let Some(cap) = re.captures(&contents) {
+                        return Some(cap[1].to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 fn find_localconfig_files() -> Vec<PathBuf> {
     let mut files = Vec::new();
+    let recent = most_recent_user_id();
     for dir in userdata_dirs() {
-        if let Ok(entries) = fs::read_dir(dir) {
+        if let Some(uid) = &recent {
+            let cfg = dir.join(uid).join("config/localconfig.vdf");
+            if cfg.exists() {
+                files.push(cfg);
+            }
+        } else if let Ok(entries) = fs::read_dir(&dir) {
             for entry in entries.flatten() {
                 let cfg = entry.path().join("config/localconfig.vdf");
-                if cfg.exists() { files.push(cfg); }
+                if cfg.exists() {
+                    files.push(cfg);
+                }
             }
         }
     }
@@ -73,4 +103,48 @@ pub fn set_launch_options(app_id: u32, value: &str) -> io::Result<()> {
         }
     }
     Err(io::Error::new(io::ErrorKind::NotFound, "localconfig not found"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use std::fs;
+    use crate::test_helpers::TEST_MUTEX;
+
+    #[test]
+    fn test_find_localconfig_files_respects_loginusers() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+
+        let userdata = home.join(".steam/steam/userdata");
+        fs::create_dir_all(&userdata).unwrap();
+        let u1 = userdata.join("111111111");
+        let u2 = userdata.join("222222222");
+        fs::create_dir_all(u1.join("config")).unwrap();
+        fs::create_dir_all(u2.join("config")).unwrap();
+        let cfg1 = u1.join("config/localconfig.vdf");
+        let cfg2 = u2.join("config/localconfig.vdf");
+        fs::write(&cfg1, "").unwrap();
+        fs::write(&cfg2, "").unwrap();
+
+        let config_dir = home.join(".steam/steam/config");
+        fs::create_dir_all(&config_dir).unwrap();
+        let login = config_dir.join("loginusers.vdf");
+        let contents = r#""users" {
+            "111111111" { "MostRecent" "0" }
+            "222222222" { "MostRecent" "1" }
+        }"#;
+        fs::write(&login, contents).unwrap();
+
+        let old_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", home); }
+
+        let files = find_localconfig_files();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0], cfg2);
+
+        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+    }
 }


### PR DESCRIPTION
## Summary
- parse loginusers.vdf to pick the most recent Steam user
- use that user when reading or writing localconfig.vdf
- add tests for multi-user selection logic
- document multi-user behaviour in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6850ab2498c4833382660fd9eea0b5d8