### PR TITLE
Check additional loginusers paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Proton Prefix Manager is a tool for locating and exploring the Proton prefixes c
 
 Steam uses Proton prefixes (Wine environments) to run Windows games on Linux. This project helps you discover where those prefixes are stored so you can inspect or manage them. You can search your installed games, locate the prefix for a specific game, and open it in your file manager. When run without any arguments, the application launches a GUI that lists your games and shows prefix details.
 
-When multiple Steam users exist, Proton Prefix Manager checks `loginusers.vdf` under Steam's `config` directory and uses the account marked with `"MostRecent" "1"`. Launch options are read from and written to that user's `localconfig.vdf`.
+When multiple Steam users exist, Proton Prefix Manager checks `loginusers.vdf` under Steam's `config` directory and uses the account marked with `"MostRecent" "1"`. If that file is missing, the tool falls back to `~/.steam/config/loginusers.vdf` and `~/.steam/root/config/loginusers.vdf`. Launch options are read from and written to that user's `localconfig.vdf`.
 
 ## Installation
 

--- a/src/utils/user_config.rs
+++ b/src/utils/user_config.rs
@@ -21,6 +21,8 @@ fn most_recent_user_id() -> Option<String> {
         let paths = [
             home.join(".steam/steam/config/loginusers.vdf"),
             home.join(".local/share/Steam/config/loginusers.vdf"),
+            home.join(".steam/config/loginusers.vdf"),
+            home.join(".steam/root/config/loginusers.vdf"),
         ];
         let re = Regex::new(r#"(?s)"(\d+)"\s*\{[^}]*"MostRecent"\s*"1""#).ok()?;
         for p in paths.iter() {
@@ -129,7 +131,7 @@ mod tests {
         fs::write(&cfg1, "").unwrap();
         fs::write(&cfg2, "").unwrap();
 
-        let config_dir = home.join(".steam/steam/config");
+        let config_dir = home.join(".steam/config");
         fs::create_dir_all(&config_dir).unwrap();
         let login = config_dir.join("loginusers.vdf");
         let contents = r#""users" {


### PR DESCRIPTION
## Summary
- support extra loginusers paths under ~/.steam
- test fallback logic for new loginusers locations
- document fallback paths in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850af5bfcfc83338def6a8fbf3e516f