### PR TITLE
Deduplicate symlinked userdata dirs

### DIFF
--- a/src/utils/user_config.rs
+++ b/src/utils/user_config.rs
@@ -8,10 +8,22 @@ use dirs_next;
 fn userdata_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     if let Some(home) = dirs_next::home_dir() {
-        let p1 = home.join(".steam/steam/userdata");
-        if p1.exists() { dirs.push(p1); }
-        let p2 = home.join(".local/share/Steam/userdata");
-        if p2.exists() { dirs.push(p2); }
+        let paths = [
+            home.join(".steam/steam/userdata"),
+            home.join(".local/share/Steam/userdata"),
+        ];
+
+        for p in paths.iter() {
+            if p.exists() {
+                if let Ok(canon) = fs::canonicalize(p) {
+                    if !dirs.contains(&canon) {
+                        dirs.push(canon);
+                    }
+                } else if !dirs.contains(p) {
+                    dirs.push(p.clone());
+                }
+            }
+        }
     }
     dirs
 }
@@ -111,6 +123,10 @@ mod tests {
     use tempfile::tempdir;
     use std::fs;
     use crate::test_helpers::TEST_MUTEX;
+    #[cfg(unix)]
+    use std::os::unix::fs as unix_fs;
+    #[cfg(windows)]
+    use std::os::windows::fs as windows_fs;
 
     #[test]
     fn test_find_localconfig_files_respects_loginusers() {
@@ -144,6 +160,33 @@ mod tests {
         let files = find_localconfig_files();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0], cfg2);
+
+        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+    }
+
+    #[test]
+    fn test_userdata_dirs_resolves_symlinks() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+
+        let p1 = home.join(".steam/steam/userdata");
+        fs::create_dir_all(&p1).unwrap();
+
+        let p2 = home.join(".local/share/Steam/userdata");
+        fs::create_dir_all(p2.parent().unwrap()).unwrap();
+
+        #[cfg(unix)]
+        unix_fs::symlink(&p1, &p2).unwrap();
+        #[cfg(windows)]
+        windows_fs::symlink_dir(&p1, &p2).unwrap();
+
+        let old_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", home); }
+
+        let dirs = userdata_dirs();
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0], fs::canonicalize(&p1).unwrap());
 
         if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
     }


### PR DESCRIPTION
## Summary
- resolve symlinks in `userdata_dirs` using `fs::canonicalize`
- avoid duplicate directories when canonical paths match
- add a unit test covering symlink handling

## Testing
- `cargo test --quiet`
- `cargo fmt -- --check` *(fails: rustfmt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850af639fec83339bd192e2e5330540