### PR TITLE
Support new app section creation for launch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Proton Prefix Manager is a tool for locating and exploring the Proton prefixes c
 
 Steam uses Proton prefixes (Wine environments) to run Windows games on Linux. This project helps you discover where those prefixes are stored so you can inspect or manage them. You can search your installed games, locate the prefix for a specific game, and open it in your file manager. When run without any arguments, the application launches a GUI that lists your games and shows prefix details.
 
-When multiple Steam users exist, Proton Prefix Manager checks `loginusers.vdf` under Steam's `config` directory and uses the account marked with `"MostRecent" "1"`. Launch options are read from and written to that user's `localconfig.vdf`.
+When multiple Steam users exist, Proton Prefix Manager checks `loginusers.vdf` under Steam's `config` directory and uses the account marked with `"MostRecent" "1"`. If that file is missing, the tool falls back to `~/.steam/config/loginusers.vdf` and `~/.steam/root/config/loginusers.vdf`. Launch options are read from and written to that user's `localconfig.vdf`.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- insert a missing app section when updating launch options
- append new sections when setting launch options if needed
- add tests for new app block creation

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6850af7179a8833381bd986ab4f4f0de