### PR TITLE
Update README about launch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Proton Prefix Manager is a tool for locating and exploring the Proton prefixes c
 
 Steam uses Proton prefixes (Wine environments) to run Windows games on Linux. This project helps you discover where those prefixes are stored so you can inspect or manage them. You can search your installed games, locate the prefix for a specific game, and open it in your file manager. When run without any arguments, the application launches a GUI that lists your games and shows prefix details.
 
-When multiple Steam users exist, Proton Prefix Manager checks `loginusers.vdf` under Steam's `config` directory and uses the account marked with `"MostRecent" "1"`. Launch options are read from and written to that user's `localconfig.vdf`.
+When multiple Steam users exist, Proton Prefix Manager checks `loginusers.vdf` under Steam's `config` directory and uses the account marked with `"MostRecent" "1"`. Launch options are first read from that user's `localconfig.vdf`; if no options are set there, they are taken from the game's `appmanifest_<AppID>.acf` file. Both files can be edited with a text editor while Steam is closed. `localconfig.vdf` is typically found in `~/.local/share/Steam/userdata/<USER_ID>/config/`, and `appmanifest_*.acf` resides in your Steam library's `steamapps` directory.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- explain launch option lookup order
- mention typical locations for localconfig and appmanifest files

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850af7c34ec8333a987f06787d31846