### PR TITLE
Fix unsafe set_var usages

### DIFF
--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -72,7 +72,7 @@ mod tests {
         let appid = 5555;
         let (home, prefix) = setup_mock_steam(appid);
         let old_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", home.path()); }
+        std::env::set_var("HOME", home.path());
 
         OPENED_PATHS.lock().unwrap().clear();
         execute(appid);
@@ -81,7 +81,7 @@ mod tests {
         assert_eq!(opened.len(), 1);
         assert_eq!(opened[0], prefix);
 
-        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
     }
 
     #[test]
@@ -92,7 +92,7 @@ mod tests {
         let (home, prefix) = setup_mock_steam(appid);
         fs::remove_dir_all(&prefix).unwrap();
         let old_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", home.path()); }
+        std::env::set_var("HOME", home.path());
 
         OPENED_PATHS.lock().unwrap().clear();
         execute(appid);
@@ -100,6 +100,6 @@ mod tests {
         let opened = OPENED_PATHS.lock().unwrap();
         assert!(opened.is_empty());
 
-        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
     }
 }

--- a/src/cli/protontricks.rs
+++ b/src/cli/protontricks.rs
@@ -93,7 +93,7 @@ mod tests {
         let appid = 1234;
         let (home, _prefix) = setup_mock_steam(appid);
         let old_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", home.path()); }
+        std::env::set_var("HOME", home.path());
 
         PROTONTRICKS_CALLS.lock().unwrap().clear();
         execute(appid, &["-v".to_string()]);
@@ -103,7 +103,7 @@ mod tests {
         assert_eq!(calls[0].0, appid);
         assert_eq!(calls[0].1, vec!["-v".to_string()]);
 
-        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
     }
 
     #[test]
@@ -114,7 +114,7 @@ mod tests {
         let (home, prefix) = setup_mock_steam(appid);
         fs::remove_dir_all(&prefix).unwrap();
         let old_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", home.path()); }
+        std::env::set_var("HOME", home.path());
 
         PROTONTRICKS_CALLS.lock().unwrap().clear();
         execute(appid, &[]);
@@ -122,6 +122,6 @@ mod tests {
         let calls = PROTONTRICKS_CALLS.lock().unwrap();
         assert!(calls.is_empty());
 
-        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
     }
 }

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -80,7 +80,7 @@ mod tests {
         let name = "Test Game";
         let home = setup_mock_steam(appid, name);
         let old_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", home.path()); }
+        std::env::set_var("HOME", home.path());
 
         SEARCH_RESULTS.lock().unwrap().clear();
         execute("test", &OutputFormat::Plain);
@@ -91,7 +91,7 @@ mod tests {
         assert_eq!(results[0][0].app_id(), appid);
         assert_eq!(results[0][0].name(), name);
 
-        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
     }
 
     #[test]
@@ -100,7 +100,7 @@ mod tests {
         crate::core::steam::clear_caches();
         let home = setup_mock_steam(8888, "Another Game");
         let old_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", home.path()); }
+        std::env::set_var("HOME", home.path());
 
         SEARCH_RESULTS.lock().unwrap().clear();
         execute("nomatch", &OutputFormat::Plain);
@@ -109,6 +109,6 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(results[0].is_empty());
 
-        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
     }
 }

--- a/src/cli/winecfg.rs
+++ b/src/cli/winecfg.rs
@@ -92,7 +92,7 @@ mod tests {
         let appid = 4321;
         let (home, prefix) = setup_mock_steam(appid);
         let old_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", home.path()); }
+        std::env::set_var("HOME", home.path());
 
         WINECFG_CALLS.lock().unwrap().clear();
         execute(appid);
@@ -101,7 +101,7 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0], prefix);
 
-        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
     }
 
     #[test]
@@ -112,7 +112,7 @@ mod tests {
         let (home, prefix) = setup_mock_steam(appid);
         fs::remove_dir_all(&prefix).unwrap();
         let old_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", home.path()); }
+        std::env::set_var("HOME", home.path());
 
         WINECFG_CALLS.lock().unwrap().clear();
         execute(appid);
@@ -120,6 +120,6 @@ mod tests {
         let calls = WINECFG_CALLS.lock().unwrap();
         assert!(calls.is_empty());
 
-        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
     }
 }

--- a/src/utils/user_config.rs
+++ b/src/utils/user_config.rs
@@ -225,13 +225,13 @@ mod tests {
         fs::write(&login, contents).unwrap();
 
         let old_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", home); }
+        std::env::set_var("HOME", home);
 
         let files = find_localconfig_files();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0], cfg2);
 
-        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
     }
 
     #[test]
@@ -252,13 +252,13 @@ mod tests {
         windows_fs::symlink_dir(&p1, &p2).unwrap();
 
         let old_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", home); }
+        std::env::set_var("HOME", home);
 
         let dirs = userdata_dirs();
         assert_eq!(dirs.len(), 1);
         assert_eq!(dirs[0], fs::canonicalize(&p1).unwrap());
 
-        if let Some(h) = old_home { unsafe { std::env::set_var("HOME", h); } }
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace unnecessary `unsafe` blocks when setting HOME env
- keep tests compiling

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850c0e323c88333ba09059826ebe307