### PR TITLE
Fix warnings and update ComboBox API

### DIFF
--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -1,4 +1,5 @@
 use crate::core::steam;
+#[cfg(not(test))]
 use crate::utils::output;
 use crate::utils::output::OutputFormat;
 use crate::core::models::GameInfo;

--- a/src/core/models.rs
+++ b/src/core/models.rs
@@ -76,6 +76,7 @@ impl GameInfo {
     }
 
     /// Checks if the Proton prefix exists.
+    #[cfg_attr(test, allow(dead_code))]
     pub fn prefix_exists(&self) -> bool {
         self.prefix_path.exists()
     }

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -467,7 +467,7 @@ impl<'a> GameDetails<'a> {
                     ui.horizontal(|ui| {
                         ui.label("Proton Version:");
                         let versions = Self::list_proton_versions();
-                        egui::ComboBox::from_id_source("proton_version")
+                        egui::ComboBox::from_id_salt("proton_version")
                             .selected_text(cfg.proton.clone().unwrap_or_else(|| "Default".to_string()))
                             .show_ui(ui, |ui| {
                                 ui.selectable_value(&mut cfg.proton, None, "Default");

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -15,6 +15,7 @@ pub struct PrefixResult {
     pub prefix_path: Option<PathBuf>,
 }
 
+#[cfg_attr(test, allow(dead_code, unused))]
 pub enum OutputFormat {
     Normal,
     Plain,
@@ -22,6 +23,7 @@ pub enum OutputFormat {
     Delimited(String),
 }
 
+#[cfg_attr(test, allow(dead_code))]
 pub fn print_search_results(results: Vec<GameInfo>, format: &OutputFormat) {
     match format {
         OutputFormat::Normal => {
@@ -84,6 +86,7 @@ pub fn print_search_results(results: Vec<GameInfo>, format: &OutputFormat) {
 }
 
 #[cfg(not(test))]
+#[cfg_attr(test, allow(dead_code))]
 pub fn print_prefix_result(appid: u32, prefix: Option<PathBuf>, format: &OutputFormat) {
     match format {
         OutputFormat::Normal => match prefix {


### PR DESCRIPTION
## Summary
- gate unused CLI imports when testing
- switch to `ComboBox::from_id_salt`
- silence dead code warnings in tests
- run tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850c231e1348333b0ab41a579c0c021