### PR TITLE
Fix GitHub link

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -253,7 +253,7 @@ impl eframe::App for ProtonPrefixManagerApp {
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     ui.hyperlink_to(
                         "GitHub",
-                        "https://github.com/yourusername/proton-prefix-manager",
+                        "https://github.com/D1G1T4L3CH0/proton-prefix-manager",
                     );
                 });
             });


### PR DESCRIPTION
## Summary
- point the GUI's GitHub link at the real repo

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850d1a66b8c8333bea55e5c57be2beb