### PR TITLE
Add debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ proton-prefix-manager winecfg 620
 
 The CLI supports JSON (`--json`), plain text (`--plain`), and custom-delimited output using `--delimiter`.
 
+## Debug logging
+
+Set `RUST_LOG=debug` to see detailed messages about configuration file discovery and updates.
+
 ## Project goals
 
 - Provide an easy way to locate Proton prefixes for troubleshooting or modding


### PR DESCRIPTION
## Summary
- instrument user_config with debug logging
- document debug logging in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850d1a429f08333a269616a905a9546