### PR TITLE
Propagate launch option update errors

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -26,7 +26,9 @@ pub fn execute(
                         Ok(mut contents) => {
                             if let Some(v) = launch {
                                 contents = manifest_utils::update_or_insert(&contents, "LaunchOptions", &v);
-                                let _ = user_config::set_launch_options(appid, &v);
+                                if let Err(e) = user_config::set_launch_options(appid, &v) {
+                                    eprintln!("Failed to update launch options: {}", e);
+                                }
                             }
                             if let Some(v) = proton {
                                 contents = manifest_utils::update_or_insert(&contents, "CompatToolOverride", &v);

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -239,7 +239,7 @@ impl<'a> GameDetails<'a> {
             if manifest.exists() {
                 let mut contents = fs::read_to_string(&manifest)?;
                 contents = manifest_utils::update_or_insert(&contents, "LaunchOptions", &cfg.launch_options);
-                let _ = user_config::set_launch_options(app_id, &cfg.launch_options);
+                user_config::set_launch_options(app_id, &cfg.launch_options)?;
                 if let Some(p) = &cfg.proton {
                     contents = manifest_utils::update_or_insert(&contents, "CompatToolOverride", p);
                 }

--- a/src/utils/user_config.rs
+++ b/src/utils/user_config.rs
@@ -268,4 +268,17 @@ mod tests {
         let updated = update_launch_options(contents, 123, "-novid").unwrap();
         assert_eq!(parse_launch_options(&updated, 123), Some("-novid".to_string()));
     }
+
+    #[test]
+    fn test_set_launch_options_missing_file() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = tempdir().unwrap();
+        let old_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", dir.path());
+
+        let result = set_launch_options(123456, "-novid");
+        assert!(result.is_err());
+
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
+    }
 }


### PR DESCRIPTION
## Summary
- log a warning when CLI launch option update fails
- propagate errors from GUI launch option updates
- test error propagation when no localconfig is found

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6850d1a076e88333ad16928bc6ead3cd