### PR TITLE
Add config-paths command

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Launch winecfg:
 proton-prefix-manager winecfg 620
 ```
 
+Show detected `localconfig.vdf` paths:
+
+```bash
+proton-prefix-manager config-paths
+```
+
 The CLI supports JSON (`--json`), plain text (`--plain`), and custom-delimited output using `--delimiter`.
 
 ## Debug logging

--- a/src/cli/config_paths.rs
+++ b/src/cli/config_paths.rs
@@ -1,0 +1,30 @@
+use crate::utils::user_config;
+
+#[cfg(test)]
+use once_cell::sync::Lazy;
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(not(test))]
+fn emit_paths(paths: Vec<std::path::PathBuf>) {
+    if paths.is_empty() {
+        println!("No localconfig.vdf files found");
+    } else {
+        for p in paths {
+            println!("{}", p.display());
+        }
+    }
+}
+
+#[cfg(test)]
+pub static EMITTED_PATHS: Lazy<Mutex<Vec<Vec<std::path::PathBuf>>>> =
+    Lazy::new(|| Mutex::new(Vec::new()));
+#[cfg(test)]
+fn emit_paths(paths: Vec<std::path::PathBuf>) {
+    EMITTED_PATHS.lock().unwrap().push(paths);
+}
+
+pub fn execute() {
+    let paths = user_config::get_localconfig_paths();
+    emit_paths(paths);
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,6 +13,7 @@ pub mod winecfg;
 pub mod restore;
 pub mod search;
 pub mod config;
+pub mod config_paths;
 
 /// Proton Prefix Manager CLI
 ///
@@ -147,4 +148,7 @@ pub enum Commands {
         #[arg(long)]
         auto_update: Option<String>,
     },
+
+    /// Show paths to discovered localconfig.vdf files
+    ConfigPaths,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,9 @@ fn main() {
                 auto_update.clone(),
             );
         }
+        Some(Commands::ConfigPaths) => {
+            cli::config_paths::execute();
+        }
         None => {
             log::info!("Launching GUI...");
             let native_options = NativeOptions::default();

--- a/src/utils/user_config.rs
+++ b/src/utils/user_config.rs
@@ -91,6 +91,11 @@ fn find_localconfig_files() -> Vec<PathBuf> {
     files
 }
 
+/// Return all discovered `localconfig.vdf` files for the current user.
+pub fn get_localconfig_paths() -> Vec<PathBuf> {
+    find_localconfig_files()
+}
+
 fn parse_launch_options(contents: &str, app_id: u32) -> Option<String> {
     let vdf = Vdf::parse(contents).ok()?;
     let root = vdf.value.get_obj()?;


### PR DESCRIPTION
## Summary
- expose user_config::get_localconfig_paths
- implement `config-paths` CLI subcommand
- wire new command in main
- document new command in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68515329fb4c8333beb1e2572f36dca4