### PR TITLE
Add config_paths CLI tests

### DIFF
--- a/src/cli/config_paths.rs
+++ b/src/cli/config_paths.rs
@@ -28,3 +28,75 @@ pub fn execute() {
     let paths = user_config::get_localconfig_paths();
     emit_paths(paths);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::TEST_MUTEX;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn setup_mock_userdata() -> (tempfile::TempDir, std::path::PathBuf) {
+        let home = tempdir().unwrap();
+        let userdata = home.path().join(".steam/steam/userdata");
+        fs::create_dir_all(&userdata).unwrap();
+
+        let u1 = userdata.join("111111111");
+        let u2 = userdata.join("222222222");
+        fs::create_dir_all(u1.join("config")).unwrap();
+        fs::create_dir_all(u2.join("config")).unwrap();
+        let cfg1 = u1.join("config/localconfig.vdf");
+        let cfg2 = u2.join("config/localconfig.vdf");
+        fs::write(&cfg1, "").unwrap();
+        fs::write(&cfg2, "").unwrap();
+
+        let config_dir = home.path().join(".steam/config");
+        fs::create_dir_all(&config_dir).unwrap();
+        let login = config_dir.join("loginusers.vdf");
+        let contents = r#""users" {
+            "111111111" { "MostRecent" "0" }
+            "222222222" { "MostRecent" "1" }
+        }"#;
+        fs::write(&login, contents).unwrap();
+
+        (home, cfg2)
+    }
+
+    #[test]
+    fn test_execute_emits_found_paths() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let (home, expected) = setup_mock_userdata();
+        let old_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", home.path());
+
+        EMITTED_PATHS.lock().unwrap().clear();
+        execute();
+
+        let emitted = EMITTED_PATHS.lock().unwrap();
+        assert_eq!(emitted.len(), 1);
+        assert_eq!(emitted[0], vec![expected]);
+
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
+    }
+
+    #[test]
+    fn test_execute_no_files_found() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        fs::create_dir_all(home.join(".steam/steam/userdata")).unwrap();
+        let old_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", home);
+
+        EMITTED_PATHS.lock().unwrap().clear();
+        execute();
+
+        let emitted = EMITTED_PATHS.lock().unwrap();
+        assert_eq!(emitted.len(), 1);
+        assert!(emitted[0].is_empty());
+
+        if let Some(h) = old_home { std::env::set_var("HOME", h); }
+    }
+}


### PR DESCRIPTION
## Summary
- test emitted paths in `config_paths` CLI command
- verify no emitted paths when configs absent

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68515cf8b04c833384d45347befcc5f2