### PR TITLE
Add reusable test Steam environment helper

### DIFF
--- a/src/cli/config_paths.rs
+++ b/src/cli/config_paths.rs
@@ -32,15 +32,18 @@ pub fn execute() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::TEST_MUTEX;
+    use crate::test_helpers::{setup_steam_env, TEST_MUTEX};
     use std::fs;
     use tempfile::tempdir;
 
-    fn setup_mock_userdata() -> (tempfile::TempDir, std::path::PathBuf) {
-        let home = tempdir().unwrap();
+    #[test]
+    fn test_execute_emits_found_paths() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let (home, _prefix, login_opt) = setup_steam_env(0, true);
+        let login = login_opt.unwrap();
         let userdata = home.path().join(".steam/steam/userdata");
         fs::create_dir_all(&userdata).unwrap();
-
         let u1 = userdata.join("111111111");
         let u2 = userdata.join("222222222");
         fs::create_dir_all(u1.join("config")).unwrap();
@@ -49,24 +52,12 @@ mod tests {
         let cfg2 = u2.join("config/localconfig.vdf");
         fs::write(&cfg1, "").unwrap();
         fs::write(&cfg2, "").unwrap();
-
-        let config_dir = home.path().join(".steam/config");
-        fs::create_dir_all(&config_dir).unwrap();
-        let login = config_dir.join("loginusers.vdf");
         let contents = r#""users" {
             "111111111" { "MostRecent" "0" }
             "222222222" { "MostRecent" "1" }
         }"#;
         fs::write(&login, contents).unwrap();
-
-        (home, cfg2)
-    }
-
-    #[test]
-    fn test_execute_emits_found_paths() {
-        let _guard = TEST_MUTEX.lock().unwrap();
-        crate::core::steam::clear_caches();
-        let (home, expected) = setup_mock_userdata();
+        let expected = cfg2.clone();
         let old_home = std::env::var("HOME").ok();
         std::env::set_var("HOME", home.path());
 

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -43,34 +43,14 @@ pub fn execute(appid: u32) {
 mod tests {
     use super::*;
     use std::fs;
-    use tempfile::tempdir;
-    use crate::test_helpers::TEST_MUTEX;
-
-    fn setup_mock_steam(appid: u32) -> (tempfile::TempDir, std::path::PathBuf) {
-        let home = tempdir().unwrap();
-        let config_dir = home.path().join(".steam/steam/config");
-        fs::create_dir_all(&config_dir).unwrap();
-
-        let library_dir = home.path().join("library");
-        let compat_path = library_dir.join("steamapps/compatdata").join(appid.to_string());
-        fs::create_dir_all(&compat_path).unwrap();
-
-        let vdf_path = config_dir.join("libraryfolders.vdf");
-        let content = format!(
-            "\"libraryfolders\" {{\n    \"0\" {{\n        \"path\" \"{}\"\n    }}\n}}",
-            library_dir.display()
-        );
-        fs::write(&vdf_path, content).unwrap();
-
-        (home, compat_path)
-    }
+    use crate::test_helpers::{TEST_MUTEX, setup_steam_env};
 
     #[test]
     fn test_execute_opens_prefix() {
         let _guard = TEST_MUTEX.lock().unwrap();
         crate::core::steam::clear_caches();
         let appid = 5555;
-        let (home, prefix) = setup_mock_steam(appid);
+        let (home, prefix, _) = setup_steam_env(appid, false);
         let old_home = std::env::var("HOME").ok();
         std::env::set_var("HOME", home.path());
 
@@ -89,7 +69,7 @@ mod tests {
         let _guard = TEST_MUTEX.lock().unwrap();
         crate::core::steam::clear_caches();
         let appid = 6666;
-        let (home, prefix) = setup_mock_steam(appid);
+        let (home, prefix, _) = setup_steam_env(appid, false);
         fs::remove_dir_all(&prefix).unwrap();
         let old_home = std::env::var("HOME").ok();
         std::env::set_var("HOME", home.path());

--- a/src/cli/prefix.rs
+++ b/src/cli/prefix.rs
@@ -41,37 +41,15 @@ pub fn execute(appid: u32, format: &OutputFormat) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::TEST_MUTEX;
+    use crate::test_helpers::{setup_steam_env, TEST_MUTEX};
     use std::fs;
-    use tempfile::tempdir;
-
-    fn setup_mock_steam(appid: u32) -> (tempfile::TempDir, std::path::PathBuf) {
-        let home = tempdir().unwrap();
-        let config_dir = home.path().join(".steam/steam/config");
-        fs::create_dir_all(&config_dir).unwrap();
-
-        let library_dir = home.path().join("library");
-        let compat_path = library_dir
-            .join("steamapps/compatdata")
-            .join(appid.to_string());
-        fs::create_dir_all(&compat_path).unwrap();
-
-        let vdf_path = config_dir.join("libraryfolders.vdf");
-        let content = format!(
-            "\"libraryfolders\" {{\n    \"0\" {{\n        \"path\" \"{}\"\n    }}\n}}",
-            library_dir.display()
-        );
-        fs::write(&vdf_path, content).unwrap();
-
-        (home, compat_path)
-    }
 
     #[test]
     fn test_execute_prefix_found() {
         let _guard = TEST_MUTEX.lock().unwrap();
         crate::core::steam::clear_caches();
         let appid = 4242;
-        let (home, prefix) = setup_mock_steam(appid);
+        let (home, prefix, _) = setup_steam_env(appid, false);
         let old_home = std::env::var("HOME").ok();
         unsafe {
             std::env::set_var("HOME", home.path());
@@ -97,7 +75,7 @@ mod tests {
         let _guard = TEST_MUTEX.lock().unwrap();
         crate::core::steam::clear_caches();
         let appid = 1337;
-        let (home, prefix) = setup_mock_steam(appid);
+        let (home, prefix, _) = setup_steam_env(appid, false);
         fs::remove_dir_all(&prefix).unwrap();
         let old_home = std::env::var("HOME").ok();
         unsafe {

--- a/src/cli/protontricks.rs
+++ b/src/cli/protontricks.rs
@@ -61,37 +61,15 @@ pub fn execute(appid: u32, args: &[String]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::TEST_MUTEX;
+    use crate::test_helpers::{setup_steam_env, TEST_MUTEX};
     use std::fs;
-    use tempfile::tempdir;
-
-    fn setup_mock_steam(appid: u32) -> (tempfile::TempDir, std::path::PathBuf) {
-        let home = tempdir().unwrap();
-        let config_dir = home.path().join(".steam/steam/config");
-        fs::create_dir_all(&config_dir).unwrap();
-
-        let library_dir = home.path().join("library");
-        let compat_path = library_dir
-            .join("steamapps/compatdata")
-            .join(appid.to_string());
-        fs::create_dir_all(&compat_path).unwrap();
-
-        let vdf_path = config_dir.join("libraryfolders.vdf");
-        let content = format!(
-            "\"libraryfolders\" {{\n    \"0\" {{\n        \"path\" \"{}\"\n    }}\n}}",
-            library_dir.display()
-        );
-        fs::write(&vdf_path, content).unwrap();
-
-        (home, compat_path)
-    }
 
     #[test]
     fn test_execute_runs_protontricks() {
         let _guard = TEST_MUTEX.lock().unwrap();
         crate::core::steam::clear_caches();
         let appid = 1234;
-        let (home, _prefix) = setup_mock_steam(appid);
+        let (home, _prefix, _) = setup_steam_env(appid, false);
         let old_home = std::env::var("HOME").ok();
         std::env::set_var("HOME", home.path());
 
@@ -111,7 +89,7 @@ mod tests {
         let _guard = TEST_MUTEX.lock().unwrap();
         crate::core::steam::clear_caches();
         let appid = 5678;
-        let (home, prefix) = setup_mock_steam(appid);
+        let (home, prefix, _) = setup_steam_env(appid, false);
         fs::remove_dir_all(&prefix).unwrap();
         let old_home = std::env::var("HOME").ok();
         std::env::set_var("HOME", home.path());

--- a/src/cli/winecfg.rs
+++ b/src/cli/winecfg.rs
@@ -60,37 +60,15 @@ pub fn execute(appid: u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::TEST_MUTEX;
+    use crate::test_helpers::{setup_steam_env, TEST_MUTEX};
     use std::fs;
-    use tempfile::tempdir;
-
-    fn setup_mock_steam(appid: u32) -> (tempfile::TempDir, std::path::PathBuf) {
-        let home = tempdir().unwrap();
-        let config_dir = home.path().join(".steam/steam/config");
-        fs::create_dir_all(&config_dir).unwrap();
-
-        let library_dir = home.path().join("library");
-        let compat_path = library_dir
-            .join("steamapps/compatdata")
-            .join(appid.to_string());
-        fs::create_dir_all(&compat_path).unwrap();
-
-        let vdf_path = config_dir.join("libraryfolders.vdf");
-        let content = format!(
-            "\"libraryfolders\" {{\n    \"0\" {{\n        \"path\" \"{}\"\n    }}\n}}",
-            library_dir.display()
-        );
-        fs::write(&vdf_path, content).unwrap();
-
-        (home, compat_path)
-    }
 
     #[test]
     fn test_execute_runs_winecfg() {
         let _guard = TEST_MUTEX.lock().unwrap();
         crate::core::steam::clear_caches();
         let appid = 4321;
-        let (home, prefix) = setup_mock_steam(appid);
+        let (home, prefix, _) = setup_steam_env(appid, false);
         let old_home = std::env::var("HOME").ok();
         std::env::set_var("HOME", home.path());
 
@@ -109,7 +87,7 @@ mod tests {
         let _guard = TEST_MUTEX.lock().unwrap();
         crate::core::steam::clear_caches();
         let appid = 8765;
-        let (home, prefix) = setup_mock_steam(appid);
+        let (home, prefix, _) = setup_steam_env(appid, false);
         fs::remove_dir_all(&prefix).unwrap();
         let old_home = std::env::var("HOME").ok();
         std::env::set_var("HOME", home.path());

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -5,3 +5,41 @@ use std::sync::Mutex;
 
 #[cfg(test)]
 pub static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[cfg(test)]
+use tempfile::TempDir;
+#[cfg(test)]
+use std::fs;
+
+/// Create a temporary Steam environment for tests.
+///
+/// Returns the temporary directory, the compatdata prefix path for the
+/// provided `appid` and optionally the path to a created `loginusers.vdf`.
+#[cfg(test)]
+pub fn setup_steam_env(appid: u32, create_loginusers: bool) -> (TempDir, std::path::PathBuf, Option<std::path::PathBuf>) {
+    let home = tempfile::tempdir().unwrap();
+    let config_dir = home.path().join(".steam/steam/config");
+    fs::create_dir_all(&config_dir).unwrap();
+
+    let library_dir = home.path().join("library");
+    let compat_path = library_dir.join("steamapps/compatdata").join(appid.to_string());
+    fs::create_dir_all(&compat_path).unwrap();
+
+    let vdf_path = config_dir.join("libraryfolders.vdf");
+    let content = format!(
+        "\"libraryfolders\" {{\n    \"0\" {{\n        \"path\" \"{}\"\n    }}\n}}",
+        library_dir.display()
+    );
+    fs::write(&vdf_path, content).unwrap();
+
+    let loginusers_path = if create_loginusers {
+        let login_path = config_dir.join("loginusers.vdf");
+        let contents = r#""users" { "111111111" { "MostRecent" "1" } }"#;
+        fs::write(&login_path, contents).unwrap();
+        Some(login_path)
+    } else {
+        None
+    };
+
+    (home, compat_path, loginusers_path)
+}


### PR DESCRIPTION
## Summary
- provide `setup_steam_env` helper for tests
- use helper in CLI test modules

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6851626c49948333a900032c4decd572