### PR TITLE
Add debug flag for verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ proton-prefix-manager config-paths
 
 The CLI supports JSON (`--json`), plain text (`--plain`), and custom-delimited output using `--delimiter`.
 
+Use `--debug` to print detailed information about paths and files the application interacts with. This enables verbose logging without having to set the `RUST_LOG` environment variable.
+
 ## Debug logging
 
-Set `RUST_LOG=debug` to see detailed messages about configuration file discovery and updates.
+You can still set `RUST_LOG=debug` for low level logging from dependencies, but in most cases the `--debug` flag is sufficient.
 
 ## Project goals
 

--- a/src/cli/backup.rs
+++ b/src/cli/backup.rs
@@ -2,6 +2,7 @@ use crate::core::steam;
 use crate::utils::backup as backup_utils;
 
 pub fn execute(appid: u32) {
+    log::debug!("backup command: appid={}", appid);
     println!("📦 Backing up Proton prefix for AppID: {}", appid);
 
     match steam::get_steam_libraries() {

--- a/src/cli/clear_cache.rs
+++ b/src/cli/clear_cache.rs
@@ -2,6 +2,7 @@ use crate::core::steam;
 use crate::utils::backup as backup_utils;
 
 pub fn execute(appid: u32) {
+    log::debug!("clear-cache command: appid={}", appid);
     match steam::get_steam_libraries() {
         Ok(libs) => match backup_utils::clear_shader_cache(appid, &libs) {
             Ok(_) => println!("Shader cache cleared"),

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -10,6 +10,14 @@ pub fn execute(
     cloud: Option<bool>,
     auto_update: Option<String>,
 ) {
+    log::debug!(
+        "config command: appid={} launch={:?} proton={:?} cloud={:?} auto_update={:?}",
+        appid,
+        launch,
+        proton,
+        cloud,
+        auto_update
+    );
     if launch.is_none() && proton.is_none() && cloud.is_none() && auto_update.is_none() {
         println!("No configuration changes specified.");
         return;

--- a/src/cli/config_paths.rs
+++ b/src/cli/config_paths.rs
@@ -25,7 +25,9 @@ fn emit_paths(paths: Vec<std::path::PathBuf>) {
 }
 
 pub fn execute() {
+    log::debug!("config-paths command");
     let paths = user_config::get_localconfig_paths();
+    log::debug!("found paths: {:?}", paths);
     emit_paths(paths);
 }
 

--- a/src/cli/delete_backup.rs
+++ b/src/cli/delete_backup.rs
@@ -4,6 +4,7 @@ use crate::core::steam;
 use crate::utils::backup as backup_utils;
 
 pub fn execute(backup: PathBuf) {
+    log::debug!("delete-backup command: path={}", backup.display());
     match steam::get_steam_libraries() {
         Ok(_libs) => match backup_utils::delete_backup(&backup) {
             Ok(_) => println!("Deleted backup {}", backup.display()),

--- a/src/cli/list_backups.rs
+++ b/src/cli/list_backups.rs
@@ -2,6 +2,7 @@ use crate::core::steam;
 use crate::utils::backup as backup_utils;
 
 pub fn execute(appid: u32) {
+    log::debug!("list-backups command: appid={}", appid);
     match steam::get_steam_libraries() {
         Ok(_libs) => {
             let backups = backup_utils::list_backups(appid);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,6 +24,10 @@ pub mod config_paths;
 #[command(name = "proton-prefix-manager")]
 #[command(about = "Find and manage Proton prefixes easily", long_about = None)]
 pub struct Cli {
+    /// Enable debug logging
+    #[arg(long, short, global = true)]
+    pub debug: bool,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -20,6 +20,7 @@ fn open_path(path: &std::path::Path) -> std::io::Result<()> {
 }
 
 pub fn execute(appid: u32) {
+    log::debug!("open command: appid={}", appid);
     println!("📂 Opening Proton prefix for AppID: {}", appid);
     
     match steam::get_steam_libraries() {

--- a/src/cli/prefix.rs
+++ b/src/cli/prefix.rs
@@ -23,6 +23,7 @@ fn emit_prefix_result(appid: u32, prefix: Option<std::path::PathBuf>, _format: &
 }
 
 pub fn execute(appid: u32, format: &OutputFormat) {
+    log::debug!("prefix command: appid={} format={:?}", appid, format);
     if matches!(format, OutputFormat::Normal) {
         println!("🔍 Locating Proton prefix for AppID: {}", appid);
     }

--- a/src/cli/protontricks.rs
+++ b/src/cli/protontricks.rs
@@ -35,6 +35,7 @@ fn run_protontricks(appid: u32, args: &[String]) -> std::io::Result<()> {
 }
 
 pub fn execute(appid: u32, args: &[String]) {
+    log::debug!("protontricks command: appid={} args={:?}", appid, args);
     println!("🔧 Running protontricks for AppID: {}", appid);
 
     if !command_available("protontricks") {

--- a/src/cli/reset.rs
+++ b/src/cli/reset.rs
@@ -2,6 +2,7 @@ use crate::core::steam;
 use crate::utils::backup as backup_utils;
 
 pub fn execute(appid: u32) {
+    log::debug!("reset command: appid={}", appid);
     match steam::get_steam_libraries() {
         Ok(libraries) => {
             if let Some(prefix) = steam::find_proton_prefix(appid, &libraries) {

--- a/src/cli/restore.rs
+++ b/src/cli/restore.rs
@@ -4,6 +4,11 @@ use crate::core::steam;
 use crate::utils::backup as backup_utils;
 
 pub fn execute(appid: u32, backup_path: PathBuf) {
+    log::debug!(
+        "restore command: appid={} backup_path={}",
+        appid,
+        backup_path.display()
+    );
     println!("♻️ Restoring Proton prefix for AppID: {}", appid);
 
     match steam::get_steam_libraries() {

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -24,6 +24,7 @@ fn emit_search_results(results: Vec<GameInfo>, _format: &OutputFormat) {
 
 
 pub fn execute(name: &str, format: &OutputFormat) {
+    log::debug!("search command: name={} format={:?}", name, format);
     if matches!(format, OutputFormat::Normal) {
         println!("🔎 Searching for '{}'", name);
     }

--- a/src/cli/winecfg.rs
+++ b/src/cli/winecfg.rs
@@ -34,6 +34,7 @@ fn run_winecfg(prefix_path: &std::path::Path) -> std::io::Result<()> {
 }
 
 pub fn execute(appid: u32) {
+    log::debug!("winecfg command: appid={}", appid);
     println!("🍷 Launching winecfg for AppID: {}", appid);
 
     if !command_available("winecfg") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,11 +51,11 @@ mod test_helpers;
 use cli::{Cli, Commands};
 use gui::ProtonPrefixManagerApp;
 use utils::output::determine_format;
+use utils::logging;
 
 fn main() {
-    env_logger::init();
-
     let cli = Cli::parse();
+    logging::init(cli.debug);
 
     match &cli.command {
         Some(Commands::Search {

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -1,0 +1,7 @@
+use env_logger::{Builder, Env};
+
+/// Initialize logging with optional debug output.
+pub fn init(debug: bool) {
+    let env = Env::default().default_filter_or(if debug { "debug" } else { "info" });
+    Builder::from_env(env).init();
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,3 +6,4 @@ pub mod dependencies;
 pub mod manifest;
 pub mod user_config;
 pub mod terminal;
+pub mod logging;

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -16,6 +16,7 @@ pub struct PrefixResult {
 }
 
 #[cfg_attr(test, allow(dead_code, unused))]
+#[derive(Debug)]
 pub enum OutputFormat {
     Normal,
     Plain,


### PR DESCRIPTION
## Summary
- add `--debug` CLI flag and setup logger
- implement logger utility
- add debug statements across CLI commands
- document debug flag in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6851660c4f988333b372d5e77f71fb59