### PR TITLE
Add doc comment for SteamID conversion

### DIFF
--- a/src/utils/user_config.rs
+++ b/src/utils/user_config.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 
 /// Search Steam userdata directories for localconfig.vdf files.
 
+/// Converts a 64-bit SteamID into the 32-bit account ID used by Steam's
+/// `userdata` directories.
 fn steamid_to_accountid(uid: &str) -> Option<String> {
     uid
         .parse::<u64>()


### PR DESCRIPTION
## Summary
- document that `steamid_to_accountid` converts a 64-bit SteamID into the account ID used by userdata folders

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685187524bc48333abbb4f3e677c49fa