### PR TITLE
Improve Proton version detection for GE-Proton

### DIFF
--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -262,7 +262,7 @@ impl<'a> GameDetails<'a> {
                 if let Ok(entries) = fs::read_dir(&common) {
                     for e in entries.flatten() {
                         if let Ok(name) = e.file_name().into_string() {
-                            if name.to_lowercase().starts_with("proton") {
+                            if name.to_lowercase().contains("proton") {
                                 versions.push(name);
                             }
                         }


### PR DESCRIPTION
## Summary
- expand Proton version detection to find custom versions like GE-Proton

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68518e29f9dc8333b4b671ddea9af91b