### PR TITLE
Add backup warning before destructive actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Reset a prefix:
 ```bash
 proton-prefix-manager reset 620
 ```
+**Warning:** Resetting a prefix will permanently delete it. It's prudent to create a backup of your important data or configuration files before performing this or any other critical action so you can restore your system if something goes wrong.
 
 Clear shader cache:
 

--- a/src/cli/reset.rs
+++ b/src/cli/reset.rs
@@ -3,6 +3,7 @@ use crate::utils::backup as backup_utils;
 
 pub fn execute(appid: u32) {
     log::debug!("reset command: appid={}", appid);
+    println!("\u{26a0}\u{fe0f} It's prudent to create a backup of your important data or configuration files before performing any critical actions. This ensures you can restore your system to a known good state if something unexpected happens.");
     match steam::get_steam_libraries() {
         Ok(libraries) => {
             if let Some(prefix) = steam::find_proton_prefix(appid, &libraries) {

--- a/src/cli/restore.rs
+++ b/src/cli/restore.rs
@@ -9,6 +9,7 @@ pub fn execute(appid: u32, backup_path: PathBuf) {
         appid,
         backup_path.display()
     );
+    println!("\u{26a0}\u{fe0f} It's prudent to create a backup of your important data or configuration files before performing any critical actions. This ensures you can restore your system to a known good state if something unexpected happens.");
     println!("♻️ Restoring Proton prefix for AppID: {}", appid);
 
     match steam::get_steam_libraries() {

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -130,15 +130,23 @@ impl<'a> GameDetails<'a> {
                 ui.close_menu();
             }
             if ui.button("Reset Prefix").clicked() {
-                match backup_utils::reset_prefix(game.prefix_path()) {
-                    Ok(_) => {
-                        tfd::message_box_ok("Reset", "Prefix deleted", tfd::MessageBoxIcon::Info)
+                if tfd::message_box_yes_no(
+                    "Confirm Reset",
+                    "Resetting will delete the prefix. It's prudent to create a backup of your important data or configuration files before performing any critical actions. This ensures you can restore your system to a known good state if something unexpected happens. Continue?",
+                    tfd::MessageBoxIcon::Warning,
+                    tfd::YesNo::No,
+                ) == tfd::YesNo::Yes
+                {
+                    match backup_utils::reset_prefix(game.prefix_path()) {
+                        Ok(_) => {
+                            tfd::message_box_ok("Reset", "Prefix deleted", tfd::MessageBoxIcon::Info)
+                        }
+                        Err(e) => tfd::message_box_ok(
+                            "Reset failed",
+                            &format!("{}", e),
+                            tfd::MessageBoxIcon::Error,
+                        ),
                     }
-                    Err(e) => tfd::message_box_ok(
-                        "Reset failed",
-                        &format!("{}", e),
-                        tfd::MessageBoxIcon::Error,
-                    ),
                 }
                 ui.close_menu();
             }


### PR DESCRIPTION
## Summary
- warn about backups for reset command in CLI
- warn about backups for restore command in CLI
- add confirmation dialog before resetting a prefix in the GUI
- document backup warning in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6851b3ba176483339d8fba55a48e165c