### PR TITLE
Enable custom Proton version selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Run the program without arguments to launch the GUI:
 proton-prefix-manager
 ```
 
-The GUI lists your installed Steam games and shows details about each prefix. You can copy or open the prefix path, run Protontricks or launch `winecfg` for the selected game, and follow external links such as SteamDB or ProtonDB.
+The GUI lists your installed Steam games and shows details about each prefix. You can copy or open the prefix path, run Protontricks or launch `winecfg` for the selected game, and follow external links such as SteamDB or ProtonDB. Game settings let you choose from built‑in and custom Proton versions discovered in `compatibilitytools.d`.
 
 ### Command line interface
 

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -4,6 +4,7 @@ use crate::core::steam;
 use crate::utils::backup as backup_utils;
 use crate::utils::manifest as manifest_utils;
 use crate::utils::prefix_validator::{self, CheckResult, CheckStatus};
+use crate::utils::steam_paths;
 use crate::utils::terminal;
 use crate::utils::user_config;
 use eframe::egui;
@@ -312,6 +313,18 @@ impl<'a> GameDetails<'a> {
                             if name.to_lowercase().contains("proton") {
                                 versions.push(name);
                             }
+                        }
+                    }
+                }
+            }
+        }
+
+        for dir in steam_paths::compatibilitytools_dirs() {
+            if let Ok(entries) = fs::read_dir(&dir) {
+                for e in entries.flatten() {
+                    if e.path().is_dir() {
+                        if let Ok(name) = e.file_name().into_string() {
+                            versions.push(name);
                         }
                     }
                 }

--- a/src/utils/steam_paths.rs
+++ b/src/utils/steam_paths.rs
@@ -75,3 +75,19 @@ pub fn config_dirs() -> Vec<PathBuf> {
 
     dirs
 }
+
+/// Directories for custom compatibility tools like GE-Proton.
+pub fn compatibilitytools_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    let mut seen = HashSet::new();
+    for base in steam_base_dirs() {
+        let p = base.join("compatibilitytools.d");
+        if p.exists() {
+            let canon = fs::canonicalize(&p).unwrap_or(p.clone());
+            if seen.insert(canon.clone()) {
+                dirs.push(canon);
+            }
+        }
+    }
+    dirs
+}


### PR DESCRIPTION
## Summary
- add `compatibilitytools_dirs` helper
- allow selecting custom Proton builds in game settings
- mention custom Proton selection in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68541878f2208333955d988a0deefad1