### PR TITLE
Add advanced search dialog

### DIFF
--- a/src/gui/advanced_search.rs
+++ b/src/gui/advanced_search.rs
@@ -1,0 +1,123 @@
+use crate::core::models::GameInfo;
+use eframe::egui;
+
+#[derive(Clone)]
+pub enum SortKey {
+    LastPlayed,
+    Name,
+    AppId,
+}
+
+impl Default for SortKey {
+    fn default() -> Self {
+        SortKey::LastPlayed
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct AdvancedSearchState {
+    pub query: String,
+    pub has_manifest: bool,
+    pub has_prefix: bool,
+    pub sort_key: SortKey,
+    pub descending: bool,
+    #[allow(dead_code)]
+    last_update: f64,
+    pub results: Vec<GameInfo>,
+}
+
+impl AdvancedSearchState {
+    pub fn perform_search(&mut self, games: &[GameInfo]) {
+        let q = self.query.to_lowercase();
+        self.results = games
+            .iter()
+            .filter(|g| {
+                (q.is_empty()
+                    || g.name().to_lowercase().contains(&q)
+                    || g.app_id().to_string().contains(&q)
+                    || g.prefix_path()
+                        .display()
+                        .to_string()
+                        .to_lowercase()
+                        .contains(&q))
+                    && (!self.has_manifest || g.has_manifest())
+                    && (!self.has_prefix || g.prefix_path().exists())
+            })
+            .cloned()
+            .collect();
+
+        self.results.sort_by(|a, b| match self.sort_key {
+            SortKey::LastPlayed => a.last_played().cmp(&b.last_played()),
+            SortKey::Name => a.name().cmp(b.name()),
+            SortKey::AppId => a.app_id().cmp(&b.app_id()),
+        });
+        if self.descending {
+            self.results.reverse();
+        }
+    }
+}
+
+pub fn advanced_search_dialog(
+    ctx: &egui::Context,
+    state: &mut AdvancedSearchState,
+    open: &mut bool,
+    games: &[GameInfo],
+    selected: &mut Option<GameInfo>,
+) {
+    egui::Window::new("Advanced Search")
+        .open(open)
+        .resizable(true)
+        .show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Search:");
+                let resp = ui.text_edit_singleline(&mut state.query);
+                if resp.changed() {
+                    state.perform_search(games);
+                }
+            });
+            ui.separator();
+            let mut changed = false;
+            changed |= ui
+                .checkbox(&mut state.has_manifest, "Has manifest")
+                .changed();
+            changed |= ui.checkbox(&mut state.has_prefix, "Has prefix").changed();
+            ui.separator();
+            egui::ComboBox::from_label("Sort By")
+                .selected_text(match state.sort_key {
+                    SortKey::LastPlayed => "Last Modified",
+                    SortKey::Name => "Name",
+                    SortKey::AppId => "AppID",
+                })
+                .show_ui(ui, |ui| {
+                    changed |= ui
+                        .selectable_value(&mut state.sort_key, SortKey::LastPlayed, "Last Modified")
+                        .changed();
+                    changed |= ui
+                        .selectable_value(&mut state.sort_key, SortKey::Name, "Name")
+                        .changed();
+                    changed |= ui
+                        .selectable_value(&mut state.sort_key, SortKey::AppId, "AppID")
+                        .changed();
+                });
+            changed |= ui.checkbox(&mut state.descending, "Descending").changed();
+            if ui.button("Clear Previous Search").clicked() {
+                *state = AdvancedSearchState::default();
+                state.perform_search(games);
+            }
+            ui.separator();
+            if changed {
+                state.perform_search(games);
+            }
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                for game in &state.results {
+                    if ui
+                        .button(format!("{} ({})", game.name(), game.app_id()))
+                        .clicked()
+                    {
+                        *selected = Some(game.clone());
+                        *open = false;
+                    }
+                }
+            });
+        });
+}

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -1,3 +1,4 @@
+use super::advanced_search::{advanced_search_dialog, AdvancedSearchState};
 use super::backup_manager::BackupManagerWindow;
 use super::details::GameConfig;
 use super::details::GameDetails;
@@ -33,6 +34,8 @@ pub struct ProtonPrefixManagerApp {
     config_cache: HashMap<u32, GameConfig>,
     show_backup_manager: bool,
     backup_manager: BackupManagerWindow,
+    show_advanced_search: bool,
+    adv_state: AdvancedSearchState,
 }
 
 impl Default for ProtonPrefixManagerApp {
@@ -61,6 +64,8 @@ impl Default for ProtonPrefixManagerApp {
             config_cache: HashMap::new(),
             show_backup_manager: false,
             backup_manager: BackupManagerWindow::new(),
+            show_advanced_search: false,
+            adv_state: AdvancedSearchState::default(),
         }
     }
 }
@@ -212,6 +217,16 @@ impl eframe::App for ProtonPrefixManagerApp {
                         self.toggle_theme(ctx);
                     }
                     if ui
+                        .small_button("🔎")
+                        .on_hover_text("Advanced Search")
+                        .clicked()
+                    {
+                        if let Ok(g) = self.installed_games.lock() {
+                            self.adv_state.perform_search(&g);
+                        }
+                        self.show_advanced_search = true;
+                    }
+                    if ui
                         .button("Manage Backups")
                         .on_hover_text("View and manage backups for all games.")
                         .clicked()
@@ -327,6 +342,18 @@ impl eframe::App for ProtonPrefixManagerApp {
         } else {
             self.backup_manager
                 .show(ctx, &mut self.show_backup_manager, None);
+        }
+
+        if let Ok(games) = self.installed_games.lock() {
+            if self.show_advanced_search {
+                advanced_search_dialog(
+                    ctx,
+                    &mut self.adv_state,
+                    &mut self.show_advanced_search,
+                    &games,
+                    &mut self.selected_game,
+                );
+            }
         }
 
         // Periodically rescan for external tools so disabled buttons can update

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,6 +1,7 @@
+mod advanced_search;
 mod app;
-mod game_list;
-mod details;
 mod backup_manager;
+mod details;
+mod game_list;
 
 pub use app::ProtonPrefixManagerApp;


### PR DESCRIPTION
## Summary
- create `advanced_search.rs` with search state and dialog helpers
- add button to open dialog and persist search state
- show dialog for selecting games and updating filters

## Testing
- `cargo check` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68541f63694c833390ebe51a7a353351