### PR TITLE
Fix advanced search window borrow issue

### DIFF
--- a/src/gui/advanced_search.rs
+++ b/src/gui/advanced_search.rs
@@ -1,7 +1,7 @@
 use crate::core::models::GameInfo;
 use eframe::egui;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum SortKey {
     LastPlayed,
     Name,
@@ -64,8 +64,10 @@ pub fn advanced_search_dialog(
     games: &[GameInfo],
     selected: &mut Option<GameInfo>,
 ) {
+    let mut window_open = *open;
+    let mut close_window = false;
     egui::Window::new("Advanced Search")
-        .open(open)
+        .open(&mut window_open)
         .resizable(true)
         .show(ctx, |ui| {
             ui.horizontal(|ui| {
@@ -115,9 +117,13 @@ pub fn advanced_search_dialog(
                         .clicked()
                     {
                         *selected = Some(game.clone());
-                        *open = false;
+                        close_window = true;
                     }
                 }
             });
         });
+    if close_window {
+        window_open = false;
+    }
+    *open = window_open;
 }


### PR DESCRIPTION
## Summary
- implement PartialEq for SortKey to allow selectable combo box
- avoid double mutable borrow in `advanced_search_dialog`
- close advanced search dialog safely on selection

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68542c1be0a483338683bbdfeea829c9