### PR TITLE
Add modal dialogs to block interaction

### DIFF
--- a/src/gui/advanced_search.rs
+++ b/src/gui/advanced_search.rs
@@ -2,6 +2,7 @@ use crate::core::models::GameInfo;
 use crate::core::steam;
 use crate::utils::{manifest as manifest_utils, user_config};
 use eframe::egui;
+use eframe::egui::Modal;
 use std::collections::HashMap;
 use std::fs;
 
@@ -217,12 +218,25 @@ pub fn advanced_search_dialog(
     games: &[GameInfo],
     selected: &mut Option<GameInfo>,
 ) {
-    let mut window_open = *open;
+    if !*open {
+        return;
+    }
+
+    let mut should_close = false;
     let mut close_window = false;
-    egui::Window::new("Advanced Search")
-        .open(&mut window_open)
-        .resizable(true)
+
+    let response = Modal::new(egui::Id::new("advanced_search"))
+        .frame(egui::Frame::window(&ctx.style()))
         .show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.heading("Advanced Search");
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.button("Close").clicked() {
+                        should_close = true;
+                    }
+                });
+            });
+            ui.separator();
             ui.horizontal(|ui| {
                 ui.label("Search:");
                 let resp = ui.text_edit_singleline(&mut state.query);
@@ -285,8 +299,12 @@ pub fn advanced_search_dialog(
                 }
             });
         });
+
     if close_window {
-        window_open = false;
+        should_close = true;
     }
-    *open = window_open;
+
+    if response.should_close() || should_close {
+        *open = false;
+    }
 }

--- a/src/gui/backup_manager.rs
+++ b/src/gui/backup_manager.rs
@@ -1,6 +1,7 @@
 use crate::core::{models::GameInfo, steam};
 use crate::utils::backup as backup_utils;
 use eframe::egui;
+use eframe::egui::Modal;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tinyfiledialogs as tfd;
@@ -125,10 +126,19 @@ impl BackupManagerWindow {
         if self.needs_refresh {
             self.refresh(games);
         }
-        egui::Window::new("Prefix Backups")
-            .open(open)
-            .vscroll(true)
+
+        let mut should_close = false;
+        let response = Modal::new(egui::Id::new("backup_manager"))
+            .frame(egui::Frame::window(&ctx.style()))
             .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.heading("Prefix Backups");
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui.button("Close").clicked() {
+                            should_close = true;
+                        }
+                    });
+                });
                 ui.horizontal(|ui| {
                     let delete_enabled = self.has_selection();
                     if ui.add_enabled(delete_enabled, egui::Button::new("Delete Selected")).clicked() {
@@ -195,5 +205,9 @@ impl BackupManagerWindow {
                     self.confirm_delete_all = false;
                 }
             });
+
+        if response.should_close() || should_close {
+            *open = false;
+        }
     }
 }

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -8,6 +8,7 @@ use crate::utils::steam_paths;
 use crate::utils::terminal;
 use crate::utils::user_config;
 use eframe::egui;
+use eframe::egui::Modal;
 use egui::menu;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -336,9 +337,23 @@ impl<'a> GameDetails<'a> {
     }
 
     fn restore_window(&mut self, ctx: &egui::Context, game: &GameInfo, open: &mut bool) {
-        egui::Window::new("Select Backup to Restore")
-            .collapsible(false)
+        if !*open {
+            return;
+        }
+
+        let mut should_close = false;
+        let response = Modal::new(egui::Id::new("restore_modal"))
+            .frame(egui::Frame::window(&ctx.style()))
             .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.heading("Select Backup to Restore");
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui.button("Close").clicked() {
+                            should_close = true;
+                        }
+                    });
+                });
+                ui.separator();
                 let backups = backup_utils::list_backups(game.app_id());
                 if backups.is_empty() {
                     ui.label("No backups found");
@@ -358,20 +373,35 @@ impl<'a> GameDetails<'a> {
                                     tfd::MessageBoxIcon::Error,
                                 ),
                             };
-                            *open = false;
+                            should_close = true;
                         }
                     }
                 }
-                if ui.button("Close").clicked() {
-                    *open = false;
-                }
             });
+
+        if response.should_close() || should_close {
+            *open = false;
+        }
     }
 
     fn delete_window(&mut self, ctx: &egui::Context, game: &GameInfo, open: &mut bool) {
-        egui::Window::new("Select Backup to Delete")
-            .collapsible(false)
+        if !*open {
+            return;
+        }
+
+        let mut should_close = false;
+        let response = Modal::new(egui::Id::new("delete_modal"))
+            .frame(egui::Frame::window(&ctx.style()))
             .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.heading("Select Backup to Delete");
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui.button("Close").clicked() {
+                            should_close = true;
+                        }
+                    });
+                });
+                ui.separator();
                 let backups = backup_utils::list_backups(game.app_id());
                 if backups.is_empty() {
                     ui.label("No backups found");
@@ -391,21 +421,35 @@ impl<'a> GameDetails<'a> {
                                     tfd::MessageBoxIcon::Error,
                                 ),
                             };
-                            *open = false;
+                            should_close = true;
                         }
                     }
                 }
-                if ui.button("Close").clicked() {
-                    *open = false;
-                }
             });
+
+        if response.should_close() || should_close {
+            *open = false;
+        }
     }
 
     fn validate_window(&self, ctx: &egui::Context, results: &[CheckResult], open: &mut bool) {
-        egui::Window::new("Prefix Validation")
-            .collapsible(false)
-            .resizable(true)
+        if !*open {
+            return;
+        }
+
+        let mut should_close = false;
+        let response = Modal::new(egui::Id::new("validate_modal"))
+            .frame(egui::Frame::window(&ctx.style()))
             .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.heading("Prefix Validation");
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui.button("Close").clicked() {
+                            should_close = true;
+                        }
+                    });
+                });
+                ui.separator();
                 egui::ScrollArea::vertical().show(ui, |ui| {
                     for r in results {
                         let (icon, color) = match r.status {
@@ -444,11 +488,11 @@ impl<'a> GameDetails<'a> {
 
                 ui.separator();
                 ui.label(summary);
-
-                if ui.button("Close").clicked() {
-                    *open = false;
-                }
             });
+
+        if response.should_close() || should_close {
+            *open = false;
+        }
     }
 
     pub fn show(


### PR DESCRIPTION
## Summary
- prevent interaction with background windows by switching dialogs to `Modal`
- add close buttons to new modal dialogs

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68544a721e7083339d30bd00d6c70807