### PR TITLE
Improve game list sorting

### DIFF
--- a/src/core/models.rs
+++ b/src/core/models.rs
@@ -2,6 +2,7 @@
 
 use crate::error::{Error, Result};
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 /// Represents a Steam game with its Proton prefix information.
 #[derive(Clone, Debug)]
@@ -20,6 +21,9 @@ pub struct GameInfo {
 
     /// Last time the game was played (Unix timestamp)
     last_played: u64,
+
+    /// Last modification time of the prefix directory
+    modified: SystemTime,
 }
 
 impl GameInfo {
@@ -41,12 +45,17 @@ impl GameInfo {
             ));
         }
 
+        let modified = std::fs::metadata(&prefix_path)
+            .and_then(|m| m.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+
         Ok(Self {
             app_id,
             name,
             prefix_path,
             has_manifest,
             last_played,
+            modified,
         })
     }
 
@@ -73,6 +82,11 @@ impl GameInfo {
     /// Gets the last played time as a Unix timestamp.
     pub fn last_played(&self) -> u64 {
         self.last_played
+    }
+
+    /// Gets the prefix last modification time.
+    pub fn modified(&self) -> SystemTime {
+        self.modified
     }
 
     /// Checks if the Proton prefix exists.

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -515,24 +515,19 @@ impl<'a> GameDetails<'a> {
                     if self.prefix_available() {
                         self.show_path(ui, "Prefix Path:", game.prefix_path());
 
-                        if let Ok(metadata) = fs::metadata(game.prefix_path()) {
-                            if let Ok(modified) = metadata.modified() {
-                                if let Ok(time) = modified.duration_since(UNIX_EPOCH) {
-                                    let datetime = chrono::DateTime::<chrono::Local>::from(
-                                        SystemTime::UNIX_EPOCH + time,
-                                    );
-                                    egui::Grid::new("modified_time")
-                                        .num_columns(2)
-                                        .spacing([8.0, 4.0])
-                                        .show(ui, |ui| {
-                                            ui.label("Last Modified:");
-                                            ui.monospace(
-                                                datetime.format("%Y-%m-%d %H:%M").to_string(),
-                                            );
-                                            ui.end_row();
-                                        });
-                                }
-                            }
+                        let modified = game.modified();
+                        if let Ok(time) = modified.duration_since(UNIX_EPOCH) {
+                            let datetime = chrono::DateTime::<chrono::Local>::from(
+                                SystemTime::UNIX_EPOCH + time,
+                            );
+                            egui::Grid::new("modified_time")
+                                .num_columns(2)
+                                .spacing([8.0, 4.0])
+                                .show(ui, |ui| {
+                                    ui.label("Last Modified:");
+                                    ui.monospace(datetime.format("%Y-%m-%d %H:%M").to_string());
+                                    ui.end_row();
+                                });
                         }
 
                         let drive_c = game.prefix_path().join("pfx/drive_c");

--- a/src/gui/game_list.rs
+++ b/src/gui/game_list.rs
@@ -1,8 +1,6 @@
 use crate::core::models::GameInfo;
 use eframe::egui;
 use std::cmp::Ordering;
-use std::fs;
-use std::time::SystemTime;
 
 /// Available sort options for the game list
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -35,12 +33,8 @@ pub(super) fn compare_games(a: &GameInfo, b: &GameInfo, sort: SortOption) -> Ord
             .to_lowercase()
             .cmp(&a.name().to_lowercase()),
         SortOption::ModifiedAsc | SortOption::ModifiedDesc => {
-            let ta = fs::metadata(a.prefix_path())
-                .and_then(|m| m.modified())
-                .unwrap_or(SystemTime::UNIX_EPOCH);
-            let tb = fs::metadata(b.prefix_path())
-                .and_then(|m| m.modified())
-                .unwrap_or(SystemTime::UNIX_EPOCH);
+            let ta = a.modified();
+            let tb = b.modified();
             if matches!(sort, SortOption::ModifiedAsc) {
                 ta.cmp(&tb)
             } else {


### PR DESCRIPTION
## Summary
- cache each game's prefix modification time when building `GameInfo`
- use cached data for sorting the game list
- show cached modification time in details panel

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6854596e3e9c833398ce17a5e38808d0