### PR TITLE
Add Steam userdata opening tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Open a prefix in your file manager:
 proton-prefix-manager open 620
 ```
 
+Open the Steam userdata directory for a game:
+
+```bash
+proton-prefix-manager userdata 620
+```
+
 Back up a prefix (stored in `~/.local/share/proton-prefix-manager/backups`):
 
 ```bash

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,17 +3,18 @@ use std::path::PathBuf;
 
 pub mod backup;
 pub mod clear_cache;
+pub mod config;
+pub mod config_paths;
 pub mod delete_backup;
 pub mod list_backups;
 pub mod open;
-pub mod protontricks;
 pub mod prefix;
+pub mod protontricks;
 pub mod reset;
-pub mod winecfg;
 pub mod restore;
 pub mod search;
-pub mod config;
-pub mod config_paths;
+pub mod userdata;
+pub mod winecfg;
 
 /// Proton Prefix Manager CLI
 ///
@@ -72,6 +73,12 @@ pub enum Commands {
 
     /// Open the Proton prefix in the file manager
     Open {
+        /// The Steam App ID of the game
+        appid: u32,
+    },
+
+    /// Open the Steam userdata directory for the given App ID
+    Userdata {
         /// The Steam App ID of the game
         appid: u32,
     },

--- a/src/cli/userdata.rs
+++ b/src/cli/userdata.rs
@@ -1,0 +1,89 @@
+use crate::core::steam;
+
+#[cfg(test)]
+use once_cell::sync::Lazy;
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(not(test))]
+fn open_path(path: &std::path::Path) -> std::io::Result<()> {
+    open::that(path)
+}
+
+#[cfg(test)]
+pub static OPENED_PATHS: Lazy<Mutex<Vec<std::path::PathBuf>>> =
+    Lazy::new(|| Mutex::new(Vec::new()));
+#[cfg(test)]
+fn open_path(path: &std::path::Path) -> std::io::Result<()> {
+    OPENED_PATHS.lock().unwrap().push(path.to_path_buf());
+    Ok(())
+}
+
+pub fn execute(appid: u32) {
+    log::debug!("userdata command: appid={}", appid);
+    println!("📂 Opening userdata for AppID: {}", appid);
+
+    match steam::find_userdata_dir(appid) {
+        Some(path) => {
+            println!("🗂  Opening folder: {}", path.display());
+            if let Err(e) = open_path(&path) {
+                eprintln!("❌ Failed to open folder: {}", e);
+            }
+        }
+        None => {
+            println!("❌ Userdata folder not found for AppID: {}", appid);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{setup_steam_env, TEST_MUTEX};
+    use std::fs;
+
+    #[test]
+    fn test_execute_opens_userdata() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let appid = 777777;
+        let (home, _prefix, _login_opt) = setup_steam_env(appid, true);
+        let userdata_base = home.path().join(".steam/steam/userdata/111111111");
+        fs::create_dir_all(userdata_base.join(appid.to_string())).unwrap();
+        let old_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", home.path());
+
+        OPENED_PATHS.lock().unwrap().clear();
+        execute(appid);
+
+        let opened = OPENED_PATHS.lock().unwrap();
+        assert_eq!(opened.len(), 1);
+        assert_eq!(opened[0], userdata_base.join(appid.to_string()));
+
+        if let Some(h) = old_home {
+            std::env::set_var("HOME", h);
+        }
+    }
+
+    #[test]
+    fn test_execute_no_userdata() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        crate::core::steam::clear_caches();
+        let appid = 888888;
+        let (home, _prefix, _login_opt) = setup_steam_env(appid, true);
+        let userdata_base = home.path().join(".steam/steam/userdata/111111111");
+        fs::create_dir_all(&userdata_base).unwrap();
+        let old_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", home.path());
+
+        OPENED_PATHS.lock().unwrap().clear();
+        execute(appid);
+
+        let opened = OPENED_PATHS.lock().unwrap();
+        assert!(opened.is_empty());
+
+        if let Some(h) = old_home {
+            std::env::set_var("HOME", h);
+        }
+    }
+}

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -193,6 +193,14 @@ impl<'a> GameDetails<'a> {
                 let _ = open::that(game.prefix_path());
                 ui.close_menu();
             }
+            if ui.button("Open Userdata Folder").clicked() {
+                if let Some(path) = steam::find_userdata_dir(game.app_id()) {
+                    let _ = open::that(path);
+                } else {
+                    eprintln!("Userdata folder not found");
+                }
+                ui.close_menu();
+            }
             if ui
                 .add_enabled(
                     *tools.get("winecfg").unwrap_or(&false),

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,9 @@ fn main() {
         Some(Commands::Open { appid }) => {
             cli::open::execute(*appid);
         }
+        Some(Commands::Userdata { appid }) => {
+            cli::userdata::execute(*appid);
+        }
         Some(Commands::Backup { appid }) => {
             cli::backup::execute(*appid);
         }


### PR DESCRIPTION
## Summary
- add new `userdata` CLI command
- implement `find_userdata_dir` in core
- support opening userdata folder from GUI prefix tools
- document usage in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685459a3d4e48333b485aab3c21d8fd7