### PR TITLE
Fix Protontricks launch behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Run the program without arguments to launch the GUI:
 proton-prefix-manager
 ```
 
-The GUI lists your installed Steam games and shows details about each prefix. You can copy or open the prefix path, run Protontricks or launch `winecfg` for the selected game, and follow external links such as SteamDB or ProtonDB. Game settings let you choose from built‑in and custom Proton versions discovered in `compatibilitytools.d`.
+The GUI lists your installed Steam games and shows details about each prefix. You can copy or open the prefix path, run Protontricks for the selected game, launch `winecfg`, and follow external links such as SteamDB or ProtonDB. Game settings let you choose from built‑in and custom Proton versions discovered in `compatibilitytools.d`.
 
 ### Command line interface
 
@@ -100,7 +100,7 @@ Clear shader cache:
 proton-prefix-manager clear-cache 620
 ```
 
-Run protontricks (opens Protontricks GUI when no command is supplied):
+Run protontricks in GUI mode for a specific AppID:
 
 ```bash
 proton-prefix-manager protontricks 620 --gui

--- a/src/cli/protontricks.rs
+++ b/src/cli/protontricks.rs
@@ -49,7 +49,7 @@ pub fn execute(appid: u32, args: &[String]) {
         Ok(libraries) => {
             if steam::find_proton_prefix(appid, &libraries).is_some() {
                 if args.is_empty() {
-                    if let Err(e) = run_protontricks(None, &["--gui".to_string()]) {
+                    if let Err(e) = run_protontricks(Some(appid), &["--gui".to_string()]) {
                         eprintln!("❌ Failed to run protontricks: {}", e);
                     }
                 } else if let Err(e) = run_protontricks(Some(appid), args) {
@@ -128,7 +128,7 @@ mod tests {
 
         let calls = PROTONTRICKS_CALLS.lock().unwrap();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, None);
+        assert_eq!(calls[0].0, Some(appid));
         assert_eq!(calls[0].1, vec!["--gui".to_string()]);
 
         if let Some(h) = old_home {


### PR DESCRIPTION
## Summary
- open Protontricks with the chosen prefix instead of prompting for a game
- update tests for new behaviour
- clarify README about Protontricks usage

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68545c96e75c8333b1b1d19295754ac0