### PR TITLE
Display userdata directory in game details

### DIFF
--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -193,14 +193,6 @@ impl<'a> GameDetails<'a> {
                 let _ = open::that(game.prefix_path());
                 ui.close_menu();
             }
-            if ui.button("Open Userdata Folder").clicked() {
-                if let Some(path) = steam::find_userdata_dir(game.app_id()) {
-                    let _ = open::that(path);
-                } else {
-                    eprintln!("Userdata folder not found");
-                }
-                ui.close_menu();
-            }
             if ui
                 .add_enabled(
                     *tools.get("winecfg").unwrap_or(&false),
@@ -606,6 +598,10 @@ impl<'a> GameDetails<'a> {
 
                     if let Some(install_dir) = find_install_dir(game.app_id()) {
                         self.show_path(ui, "Install Directory:", &install_dir);
+                    }
+
+                    if let Some(user_dir) = steam::find_userdata_dir(game.app_id()) {
+                        self.show_path(ui, "Userdata Directory:", &user_dir);
                     }
                 });
 


### PR DESCRIPTION
## Summary
- show the Steam userdata path in the Game Details panel
- remove the userdata folder option from Prefix Tools menu

## Testing
- `cargo clippy -- -D warnings` *(fails: collapsible_if, deprecated, too-many-arguments, etc.)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68545cf56e348333b60f10cc4fbca03c