### PR TITLE
Move prefix tools to toolbar

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -253,6 +253,20 @@ impl eframe::App for ProtonPrefixManagerApp {
                     {
                         self.show_backup_manager = true;
                     }
+                    if let Some(game) = self.selected_game.as_ref() {
+                        let details = GameDetails::new(Some(game));
+                        details.prefix_tools_menu(
+                            ui,
+                            game,
+                            &mut self.restore_dialog_open,
+                            &mut self.delete_dialog_open,
+                            &mut self.validation_dialog_open,
+                            &mut self.validation_results,
+                            &self.tool_status,
+                            &mut self.status_message,
+                            &mut self.last_status_update,
+                        );
+                    }
                 });
             });
 
@@ -356,10 +370,7 @@ impl eframe::App for ProtonPrefixManagerApp {
                             &mut self.delete_dialog_open,
                             &mut self.validation_dialog_open,
                             &mut self.validation_results,
-                            &self.tool_status,
                             &mut self.config_cache,
-                            &mut self.status_message,
-                            &mut self.last_status_update,
                         );
                     });
             });

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -97,7 +97,7 @@ impl<'a> GameDetails<'a> {
         ui.add_space(8.0);
     }
 
-    fn prefix_tools_menu(
+    pub fn prefix_tools_menu(
         &self,
         ui: &mut egui::Ui,
         game: &GameInfo,
@@ -109,7 +109,7 @@ impl<'a> GameDetails<'a> {
         status_message: &mut Option<String>,
         status_time: &mut f64,
     ) {
-        menu::menu_button(ui, "Tools ▾", |ui| {
+        menu::menu_button(ui, "Prefix Tools ▾", |ui| {
             ui.menu_button("Prefix ▾", |ui| {
                 if ui.button("Backup").clicked() {
                     match backup_utils::create_backup(game.prefix_path(), game.app_id()) {
@@ -509,10 +509,7 @@ impl<'a> GameDetails<'a> {
         delete_dialog_open: &mut bool,
         validation_dialog_open: &mut bool,
         validation_results: &mut Vec<CheckResult>,
-        tools: &BTreeMap<String, bool>,
         configs: &mut HashMap<u32, GameConfig>,
-        status_message: &mut Option<String>,
-        status_time: &mut f64,
     ) {
         if let Some(game) = self.game {
             self.game_title_bar(ui, game);
@@ -547,19 +544,7 @@ impl<'a> GameDetails<'a> {
                         ui.label("No prefix currently exists for this game.");
                     }
 
-                    ui.horizontal(|ui| {
-                        self.prefix_tools_menu(
-                            ui,
-                            game,
-                            restore_dialog_open,
-                            delete_dialog_open,
-                            validation_dialog_open,
-                            validation_results,
-                            tools,
-                            status_message,
-                            status_time,
-                        );
-                    });
+                    // Tools moved to the top toolbar
                 });
 
             // Proton Information


### PR DESCRIPTION
## Summary
- make `prefix_tools_menu` public and rename to "Prefix Tools"
- remove tools section from game details
- show the new "Prefix Tools" dropdown next to Manage Backups

## Testing
- `cargo check`
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68546acfbd588333aa15cb5d1d21dbea