### PR TITLE
Add Steam compatibility override

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -40,6 +40,9 @@ pub fn execute(
                             }
                             if let Some(v) = proton {
                                 contents = manifest_utils::update_or_insert(&contents, "CompatToolOverride", &v);
+                                if let Err(e) = user_config::set_compat_tool(appid, &v) {
+                                    eprintln!("Failed to update compatibility tool: {}", e);
+                                }
                             }
                             if let Some(v) = cloud {
                                 let val = if v { "1" } else { "0" };

--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -293,6 +293,9 @@ impl<'a> GameDetails<'a> {
                 user_config::set_launch_options(app_id, &cfg.launch_options)?;
                 if let Some(p) = &cfg.proton {
                     contents = manifest_utils::update_or_insert(&contents, "CompatToolOverride", p);
+                    user_config::set_compat_tool(app_id, p)?;
+                } else {
+                    let _ = user_config::clear_compat_tool(app_id);
                 }
                 let cloud_val = if cfg.cloud_sync { "1" } else { "0" };
                 contents =


### PR DESCRIPTION
## Summary
- support compat tool override in user_config
- wire GUI & CLI to update compat tool overrides in localconfig.vdf
- tests for compat tool helper functions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68546c996a408333b5c89bc8ecb79935