### PR TITLE
Improve GUI performance with cached prefix info

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -1,7 +1,6 @@
 use super::advanced_search::{advanced_search_dialog, AdvancedSearchState};
 use super::backup_manager::BackupManagerWindow;
-use super::details::GameConfig;
-use super::details::GameDetails;
+use super::details::{GameConfig, GameDetails, PrefixInfo};
 use super::game_list::{compare_games, GameList};
 use super::SortOption;
 use crate::core::models::GameInfo;
@@ -34,6 +33,7 @@ pub struct ProtonPrefixManagerApp {
     tool_status: BTreeMap<String, bool>,
     last_tool_scan: f64,
     config_cache: HashMap<u32, GameConfig>,
+    prefix_cache: HashMap<u32, PrefixInfo>,
     show_backup_manager: bool,
     backup_manager: BackupManagerWindow,
     show_advanced_search: bool,
@@ -66,6 +66,7 @@ impl Default for ProtonPrefixManagerApp {
             },
             last_tool_scan: 0.0,
             config_cache: HashMap::new(),
+            prefix_cache: HashMap::new(),
             show_backup_manager: false,
             backup_manager: BackupManagerWindow::new(),
             show_advanced_search: false,
@@ -356,6 +357,8 @@ impl eframe::App for ProtonPrefixManagerApp {
                         self.selected_game = Some(updated);
                     }
                     self.config_cache.remove(&id);
+                    self.prefix_cache
+                        .insert(id, super::details::collect_prefix_info(self.selected_game.as_ref().unwrap().prefix_path()));
                 }
             }
 
@@ -371,6 +374,7 @@ impl eframe::App for ProtonPrefixManagerApp {
                             &mut self.validation_dialog_open,
                             &mut self.validation_results,
                             &mut self.config_cache,
+                            &mut self.prefix_cache,
                         );
                     });
             });

--- a/src/gui/game_list.rs
+++ b/src/gui/game_list.rs
@@ -84,15 +84,10 @@ impl<'a> GameList<'a> {
                 return;
             }
 
-            // Prepare sorted games based on the selected option
-            let mut sorted_games: Vec<&GameInfo> = self.games.iter().collect();
-            sorted_games.sort_by(|a, b| compare_games(a, b, *sort_option));
-
             egui::ScrollArea::vertical()
                 .auto_shrink([false, false])
                 .show(ui, |ui| {
-                    // Render all items
-                    for game in sorted_games {
+                    for game in self.games {
                         let is_selected = selected_game
                             .as_ref()
                             .map_or(false, |g| g.app_id() == game.app_id());


### PR DESCRIPTION
## Summary
- add `PrefixInfo` struct to cache Proton details
- cache Proton version list with `OnceCell`
- reuse cached prefix info in `GameDetails`
- store prefix info in `ProtonPrefixManagerApp`
- skip per-frame sorting in `GameList`

## Testing
- `cargo check`
- `cargo test`
- `cargo fmt -- --check`

------
https://chatgpt.com/codex/tasks/task_e_685486a27a3c8333b260edd4f44cae8d