### PR TITLE
Async load for backup manager

### DIFF
--- a/src/gui/backup_manager.rs
+++ b/src/gui/backup_manager.rs
@@ -2,6 +2,8 @@ use crate::core::{models::GameInfo, steam};
 use crate::utils::backup as backup_utils;
 use eframe::egui;
 use eframe::egui::Modal;
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tinyfiledialogs as tfd;
@@ -19,6 +21,8 @@ pub struct BackupManagerWindow {
     entries: Vec<BackupEntry>,
     confirm_delete_all: bool,
     needs_refresh: bool,
+    loading: bool,
+    rx: Option<Receiver<Vec<BackupEntry>>>,
 }
 
 impl BackupManagerWindow {
@@ -27,6 +31,8 @@ impl BackupManagerWindow {
             entries: Vec::new(),
             confirm_delete_all: false,
             needs_refresh: true,
+            loading: false,
+            rx: None,
         }
     }
 
@@ -60,18 +66,19 @@ impl BackupManagerWindow {
         }
     }
 
-    fn refresh(&mut self, games: Option<&[GameInfo]>) {
-        self.entries.clear();
+    fn collect_entries(games: Option<Vec<GameInfo>>) -> Vec<BackupEntry> {
         let all = backup_utils::list_all_backups();
+        let mut entries = Vec::new();
         for (appid, backups) in all {
             let game_name = games
+                .as_deref()
                 .and_then(|g| g.iter().find(|x| x.app_id() == appid))
                 .map(|g| g.name().to_string())
                 .unwrap_or_else(|| format!("App {}", appid));
             for b in backups {
                 let size = Self::dir_size(&b).unwrap_or(0);
                 let created = backup_utils::format_backup_name(&b);
-                self.entries.push(BackupEntry {
+                entries.push(BackupEntry {
                     app_id: appid,
                     game_name: game_name.clone(),
                     path: b,
@@ -81,7 +88,22 @@ impl BackupManagerWindow {
                 });
             }
         }
-        self.needs_refresh = false;
+        entries
+    }
+
+    fn start_refresh(&mut self, games: Option<&[GameInfo]>) {
+        self.entries.clear();
+        self.loading = true;
+        let rx_slot = {
+            let games_owned = games.map(|g| g.to_vec());
+            let (tx, rx) = mpsc::channel();
+            thread::spawn(move || {
+                let entries = Self::collect_entries(games_owned);
+                let _ = tx.send(entries);
+            });
+            rx
+        };
+        self.rx = Some(rx_slot);
     }
 
     fn prefix_for(app_id: u32, games: Option<&[GameInfo]>) -> Option<PathBuf> {
@@ -123,8 +145,17 @@ impl BackupManagerWindow {
             self.needs_refresh = true;
             return;
         }
-        if self.needs_refresh {
-            self.refresh(games);
+        if self.needs_refresh && !self.loading {
+            self.start_refresh(games);
+        }
+
+        if let Some(rx) = &self.rx {
+            if let Ok(entries) = rx.try_recv() {
+                self.entries = entries;
+                self.loading = false;
+                self.needs_refresh = false;
+                self.rx = None;
+            }
         }
 
         let mut should_close = false;
@@ -157,52 +188,59 @@ impl BackupManagerWindow {
                     }
                 });
 
-                egui::Grid::new("backups_grid")
-                    .striped(true)
-                    .show(ui, |ui| {
-                        ui.heading("Game Name");
-                        ui.heading("App ID");
-                        ui.heading("Backup");
-                        ui.heading("Size");
-                        ui.heading("Actions");
-                        ui.end_row();
-
-                        for entry in &mut self.entries {
-                            ui.label(&entry.game_name);
-                            ui.label(entry.app_id.to_string());
-                            ui.label(&entry.created);
-                            ui.label(Self::format_size(entry.size));
-                            ui.horizontal(|ui| {
-                                if ui.button("Restore").clicked() {
-                                    if let Some(prefix) = Self::prefix_for(entry.app_id, games) {
-                                        match backup_utils::restore_prefix(&entry.path, &prefix) {
-                                            Ok(_) => tfd::message_box_ok("Restore", "Prefix restored", tfd::MessageBoxIcon::Info),
-                                            Err(e) => tfd::message_box_ok("Restore failed", &format!("{}", e), tfd::MessageBoxIcon::Error),
-                                        };
-                                    } else {
-                                        tfd::message_box_ok("Restore failed", "Prefix path not found", tfd::MessageBoxIcon::Error);
-                                    }
-                                }
-                                if ui.button("Delete").clicked() {
-                                    match backup_utils::delete_backup(&entry.path) {
-                                        Ok(_) => tfd::message_box_ok(
-                                            "Delete",
-                                            "Backup removed",
-                                            tfd::MessageBoxIcon::Info,
-                                        ),
-                                        Err(e) => tfd::message_box_ok(
-                                            "Delete failed",
-                                            &format!("{}", e),
-                                            tfd::MessageBoxIcon::Error,
-                                        ),
-                                    };
-                                    self.needs_refresh = true;
-                                }
-                            });
-                            ui.checkbox(&mut entry.selected, "");
-                            ui.end_row();
-                        }
+                if self.loading {
+                    ui.centered_and_justified(|ui| {
+                        ui.spinner();
+                        ui.label("Loading backups...");
                     });
+                } else {
+                    egui::Grid::new("backups_grid")
+                        .striped(true)
+                        .show(ui, |ui| {
+                            ui.heading("Game Name");
+                            ui.heading("App ID");
+                            ui.heading("Backup");
+                            ui.heading("Size");
+                            ui.heading("Actions");
+                            ui.end_row();
+
+                            for entry in &mut self.entries {
+                                ui.label(&entry.game_name);
+                                ui.label(entry.app_id.to_string());
+                                ui.label(&entry.created);
+                                ui.label(Self::format_size(entry.size));
+                                ui.horizontal(|ui| {
+                                    if ui.button("Restore").clicked() {
+                                        if let Some(prefix) = Self::prefix_for(entry.app_id, games) {
+                                            match backup_utils::restore_prefix(&entry.path, &prefix) {
+                                                Ok(_) => tfd::message_box_ok("Restore", "Prefix restored", tfd::MessageBoxIcon::Info),
+                                                Err(e) => tfd::message_box_ok("Restore failed", &format!("{}", e), tfd::MessageBoxIcon::Error),
+                                            };
+                                        } else {
+                                            tfd::message_box_ok("Restore failed", "Prefix path not found", tfd::MessageBoxIcon::Error);
+                                        }
+                                    }
+                                    if ui.button("Delete").clicked() {
+                                        match backup_utils::delete_backup(&entry.path) {
+                                            Ok(_) => tfd::message_box_ok(
+                                                "Delete",
+                                                "Backup removed",
+                                                tfd::MessageBoxIcon::Info,
+                                            ),
+                                            Err(e) => tfd::message_box_ok(
+                                                "Delete failed",
+                                                &format!("{}", e),
+                                                tfd::MessageBoxIcon::Error,
+                                            ),
+                                        };
+                                        self.needs_refresh = true;
+                                    }
+                                });
+                                ui.checkbox(&mut entry.selected, "");
+                                ui.end_row();
+                            }
+                        });
+                }
 
                 if self.confirm_delete_all {
                     if tfd::message_box_yes_no(


### PR DESCRIPTION
## Summary
- load backup entries in a background thread
- show spinner while backups load

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68548a5b46d883339b423430eb3091be