### PR TITLE
Fix compile warnings

### DIFF
--- a/src/core/steam.rs
+++ b/src/core/steam.rs
@@ -120,7 +120,7 @@ pub fn find_proton_prefix(appid: u32, libraries: &[SteamLibrary]) -> Option<Path
 /// determine the account ID and checks all detected `userdata` bases.
 /// Returns `Some(PathBuf)` if the directory exists.
 pub fn find_userdata_dir(appid: u32) -> Option<PathBuf> {
-    if let Some(cfg) = crate::utils::user_config::expected_localconfig_path() {
+    if let Some(cfg) = user_config::expected_localconfig_path() {
         if let Some(user_dir) = cfg.parent().and_then(|p| p.parent()) {
             let candidate = user_dir.join(appid.to_string());
             if candidate.exists() {

--- a/src/gui/game_list.rs
+++ b/src/gui/game_list.rs
@@ -66,7 +66,7 @@ impl<'a> GameList<'a> {
             ui.horizontal(|ui| {
                 ui.label("Sort by:");
                 let prev = *sort_option;
-                egui::ComboBox::from_id_source("sort_combo")
+                egui::ComboBox::from_id_salt("sort_combo")
                     .selected_text(sort_option.label())
                     .show_ui(ui, |ui| {
                         ui.selectable_value(sort_option, SortOption::ModifiedDesc, SortOption::ModifiedDesc.label());

--- a/src/utils/user_config.rs
+++ b/src/utils/user_config.rs
@@ -195,6 +195,8 @@ pub fn expected_localconfig_path() -> Option<PathBuf> {
     default_localconfig_path()
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 fn parse_compat_tool(contents: &str, app_id: u32) -> Option<String> {
     let vdf = Vdf::parse(contents).ok()?;
     let mut root = vdf.value.get_obj()?;
@@ -231,6 +233,8 @@ fn parse_compat_tool(contents: &str, app_id: u32) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 pub fn get_compat_tool(app_id: u32) -> Option<String> {
     for cfg in find_localconfig_files() {
         match read_localconfig_cached(&cfg) {


### PR DESCRIPTION
## Summary
- fix unused import in `steam.rs`
- replace deprecated `ComboBox::from_id_source` with `from_id_salt`
- make unused helper functions test-only

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68549046fa3883338b8b38a2a5ee385c