### PR TITLE
Fix game settings collapse when changing Proton version

### DIFF
--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -640,6 +640,7 @@ impl<'a> GameDetails<'a> {
                 "⚙ Game Settings"
             };
             egui::CollapsingHeader::new(header_label)
+                .id_salt("game_settings_header")
                 .default_open(has_custom)
                 .show(ui, |ui| {
                     ui.horizontal(|ui| {
@@ -660,7 +661,7 @@ impl<'a> GameDetails<'a> {
                         ui.label("Launch Options:");
                         ui.add(
                             egui::TextEdit::singleline(&mut cfg.launch_options)
-                                .id_source("launch_options")
+                                .id_salt("launch_options")
                                 .hint_text("e.g. PROTON_LOG=1"),
                         );
                     });


### PR DESCRIPTION
## Summary
- preserve header state for the Game Settings section
- keep text edit id stable

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68549204459c83339d0a72f539d49aa0