### PR TITLE
Add Steam Runtime Cleaner

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -2,6 +2,7 @@ use super::advanced_search::{advanced_search_dialog, AdvancedSearchState};
 use super::backup_manager::BackupManagerWindow;
 use super::details::{GameConfig, GameDetails, PrefixInfo};
 use super::game_list::{compare_games, GameList};
+use super::runtime_cleaner::RuntimeCleanerWindow;
 use super::SortOption;
 use crate::core::models::GameInfo;
 use crate::core::steam;
@@ -36,6 +37,8 @@ pub struct ProtonPrefixManagerApp {
     prefix_cache: HashMap<u32, PrefixInfo>,
     show_backup_manager: bool,
     backup_manager: BackupManagerWindow,
+    show_runtime_cleaner: bool,
+    runtime_cleaner: RuntimeCleanerWindow,
     show_advanced_search: bool,
     adv_state: AdvancedSearchState,
     sort_option: SortOption,
@@ -69,6 +72,8 @@ impl Default for ProtonPrefixManagerApp {
             prefix_cache: HashMap::new(),
             show_backup_manager: false,
             backup_manager: BackupManagerWindow::new(),
+            show_runtime_cleaner: false,
+            runtime_cleaner: RuntimeCleanerWindow::new(),
             show_advanced_search: false,
             adv_state: AdvancedSearchState::default(),
             sort_option: SortOption::ModifiedDesc,
@@ -267,6 +272,13 @@ impl eframe::App for ProtonPrefixManagerApp {
                     {
                         self.show_backup_manager = true;
                     }
+                    if ui
+                        .button("Steam Runtime Cleaner")
+                        .on_hover_text("Find leftover data to delete.")
+                        .clicked()
+                    {
+                        self.show_runtime_cleaner = true;
+                    }
                     if let Some(game) = self.selected_game.as_ref() {
                         let details = GameDetails::new(Some(game));
                         details.prefix_tools_menu(
@@ -371,8 +383,12 @@ impl eframe::App for ProtonPrefixManagerApp {
                         self.selected_game = Some(updated);
                     }
                     self.config_cache.remove(&id);
-                    self.prefix_cache
-                        .insert(id, super::details::collect_prefix_info(self.selected_game.as_ref().unwrap().prefix_path()));
+                    self.prefix_cache.insert(
+                        id,
+                        super::details::collect_prefix_info(
+                            self.selected_game.as_ref().unwrap().prefix_path(),
+                        ),
+                    );
                 } else {
                     self.clear_selection_data(None);
                 }
@@ -403,6 +419,9 @@ impl eframe::App for ProtonPrefixManagerApp {
             self.backup_manager
                 .show(ctx, &mut self.show_backup_manager, None);
         }
+
+        self.runtime_cleaner
+            .show(ctx, &mut self.show_runtime_cleaner);
 
         if let Ok(games) = self.installed_games.lock() {
             if self.show_advanced_search {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -3,6 +3,7 @@ mod app;
 mod backup_manager;
 mod details;
 mod game_list;
+mod runtime_cleaner;
 
 pub use game_list::SortOption;
 

--- a/src/gui/runtime_cleaner.rs
+++ b/src/gui/runtime_cleaner.rs
@@ -1,0 +1,190 @@
+use crate::utils::runtime_cleaner::{delete_item, scan, RuntimeItem, ScanResults};
+use eframe::egui::{self, Modal};
+use open;
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use tinyfiledialogs as tfd;
+
+pub struct RuntimeCleanerWindow {
+    results: ScanResults,
+    loading: bool,
+    rx: Option<Receiver<ScanResults>>,
+    needs_refresh: bool,
+}
+
+impl RuntimeCleanerWindow {
+    pub fn new() -> Self {
+        Self {
+            results: ScanResults::default(),
+            loading: false,
+            rx: None,
+            needs_refresh: true,
+        }
+    }
+
+    fn start_scan(&mut self) {
+        self.loading = true;
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let res = scan();
+            let _ = tx.send(res);
+        });
+        self.rx = Some(rx);
+    }
+
+    fn any_selected(&self) -> bool {
+        self.results.install_folders.iter().any(|i| i.selected)
+            || self.results.prefixes.iter().any(|i| i.selected)
+            || self.results.shader_caches.iter().any(|i| i.selected)
+            || self.results.tools.iter().any(|i| i.selected)
+    }
+
+    fn select_all(&mut self, val: bool) {
+        for list in [
+            &mut self.results.install_folders,
+            &mut self.results.prefixes,
+            &mut self.results.shader_caches,
+            &mut self.results.tools,
+        ] {
+            for item in list.iter_mut() {
+                item.selected = val;
+            }
+        }
+    }
+
+    fn delete_selected(&mut self) {
+        for list in [
+            &mut self.results.install_folders,
+            &mut self.results.prefixes,
+            &mut self.results.shader_caches,
+            &mut self.results.tools,
+        ] {
+            let mut idx = 0;
+            while idx < list.len() {
+                if list[idx].selected {
+                    if delete_item(&list[idx]).is_ok() {
+                        list.remove(idx);
+                        continue;
+                    }
+                }
+                idx += 1;
+            }
+        }
+    }
+
+    pub fn show(&mut self, ctx: &egui::Context, open: &mut bool) {
+        if !*open {
+            self.rx = None;
+            self.loading = false;
+            self.needs_refresh = true;
+            return;
+        }
+
+        if self.needs_refresh && !self.loading {
+            self.start_scan();
+        }
+
+        if let Some(rx) = &self.rx {
+            if let Ok(res) = rx.try_recv() {
+                self.results = res;
+                self.loading = false;
+                self.needs_refresh = false;
+                self.rx = None;
+            }
+        }
+
+        let mut should_close = false;
+        let response = Modal::new(egui::Id::new("runtime_cleaner"))
+            .frame(egui::Frame::window(&ctx.style()))
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.heading("Steam Runtime Cleaner");
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui.button("Close").clicked() {
+                            should_close = true;
+                        }
+                    });
+                });
+
+                ui.horizontal(|ui| {
+                    if ui.button("Select All").clicked() {
+                        self.select_all(true);
+                    }
+                    if ui.button("Deselect All").clicked() {
+                        self.select_all(false);
+                    }
+                    if ui
+                        .add_enabled(self.any_selected(), egui::Button::new("Delete Selected"))
+                        .clicked()
+                    {
+                        if tfd::message_box_yes_no(
+                            "Confirm",
+                            "Delete selected items?",
+                            tfd::MessageBoxIcon::Warning,
+                            tfd::YesNo::No,
+                        ) == tfd::YesNo::Yes
+                        {
+                            self.delete_selected();
+                        }
+                    }
+                });
+
+                ui.separator();
+
+                if self.loading {
+                    ui.centered_and_justified(|ui| {
+                        ui.spinner();
+                        ui.label("Scanning...");
+                    });
+                    return;
+                }
+
+                Self::show_group(
+                    ui,
+                    "Orphaned Install Folders",
+                    &mut self.results.install_folders,
+                );
+                Self::show_group(ui, "Orphaned Proton Prefixes", &mut self.results.prefixes);
+                Self::show_group(ui, "Unused Shader Caches", &mut self.results.shader_caches);
+                Self::show_group(ui, "Broken Custom Proton Versions", &mut self.results.tools);
+            });
+
+        if response.should_close() || should_close {
+            *open = false;
+        }
+    }
+
+    fn show_group(ui: &mut egui::Ui, title: &str, items: &mut Vec<RuntimeItem>) {
+        egui::CollapsingHeader::new(title)
+            .default_open(true)
+            .show(ui, |ui| {
+                for item in items.iter_mut() {
+                    ui.horizontal(|ui| {
+                        ui.checkbox(&mut item.selected, "");
+                        if ui
+                            .button("📂")
+                            .on_hover_text("Show in File Manager")
+                            .clicked()
+                        {
+                            let _ = open::that(&item.path);
+                        }
+                        let lbl = if let Some(id) = item.app_id {
+                            format!("{} (AppID {})", item.path.display(), id)
+                        } else {
+                            item.path.display().to_string()
+                        };
+                        ui.label(lbl);
+                        ui.label(egui::RichText::new(&item.reason).italics());
+                        if !item.verified {
+                            ui.label(
+                                egui::RichText::new("[unverified]").color(egui::Color32::YELLOW),
+                            );
+                        }
+                    });
+                }
+                if items.is_empty() {
+                    ui.label("None found");
+                }
+            });
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@ pub mod logging;
 pub mod manifest;
 pub mod output;
 pub mod prefix_validator;
+pub mod runtime_cleaner;
 pub mod steam_paths;
 pub mod terminal;
 pub mod user_config;

--- a/src/utils/runtime_cleaner.rs
+++ b/src/utils/runtime_cleaner.rs
@@ -1,0 +1,132 @@
+use crate::core::steam;
+use crate::utils::library::parse_appmanifest_installdir;
+use crate::utils::steam_paths;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone)]
+pub struct RuntimeItem {
+    pub path: PathBuf,
+    pub app_id: Option<u32>,
+    pub reason: String,
+    pub selected: bool,
+    pub verified: bool,
+}
+
+#[derive(Default)]
+pub struct ScanResults {
+    pub install_folders: Vec<RuntimeItem>,
+    pub prefixes: Vec<RuntimeItem>,
+    pub shader_caches: Vec<RuntimeItem>,
+    pub tools: Vec<RuntimeItem>,
+}
+
+fn is_valid_tool(dir: &Path) -> bool {
+    dir.join("proton").exists() || dir.join("proton.sh").exists()
+}
+
+pub fn scan() -> ScanResults {
+    let mut results = ScanResults::default();
+    if let Ok(libraries) = steam::get_steam_libraries() {
+        let mut appids = HashSet::new();
+        let mut installdirs = HashSet::new();
+        for lib in &libraries {
+            let steamapps = lib.steamapps_path();
+            if let Ok(entries) = fs::read_dir(&steamapps) {
+                for e in entries.flatten() {
+                    let p = e.path();
+                    if p.extension().and_then(|s| s.to_str()) == Some("acf") {
+                        if let Some((appid, dir)) = parse_appmanifest_installdir(&p) {
+                            appids.insert(appid);
+                            installdirs.insert(dir);
+                        }
+                    }
+                }
+            }
+        }
+        // Orphaned install folders
+        for lib in &libraries {
+            let common = lib.steamapps_path().join("common");
+            if let Ok(entries) = fs::read_dir(&common) {
+                for e in entries.flatten() {
+                    let p = e.path();
+                    if p.is_dir() {
+                        if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
+                            if !installdirs.contains(name) {
+                                results.install_folders.push(RuntimeItem {
+                                    path: p,
+                                    app_id: None,
+                                    reason: "No matching appmanifest".to_string(),
+                                    selected: true,
+                                    verified: true,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Orphaned prefixes
+        for lib in &libraries {
+            let compat = lib.compatdata_path();
+            if let Ok(entries) = fs::read_dir(&compat) {
+                for e in entries.flatten() {
+                    if let Ok(app) = e.file_name().to_string_lossy().parse::<u32>() {
+                        if !appids.contains(&app) {
+                            results.prefixes.push(RuntimeItem {
+                                path: e.path(),
+                                app_id: Some(app),
+                                reason: format!("No appmanifest found for AppID {}", app),
+                                selected: true,
+                                verified: true,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        // Unused shader cache
+        for lib in &libraries {
+            let shader = lib.steamapps_path().join("shadercache");
+            if let Ok(entries) = fs::read_dir(&shader) {
+                for e in entries.flatten() {
+                    if let Ok(app) = e.file_name().to_string_lossy().parse::<u32>() {
+                        if !appids.contains(&app) {
+                            results.shader_caches.push(RuntimeItem {
+                                path: e.path(),
+                                app_id: Some(app),
+                                reason: format!("No appmanifest found for AppID {}", app),
+                                selected: true,
+                                verified: true,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // custom Proton tools
+    for dir in steam_paths::compatibilitytools_dirs() {
+        if let Ok(entries) = fs::read_dir(&dir) {
+            for e in entries.flatten() {
+                if e.path().is_dir() && !is_valid_tool(&e.path()) {
+                    results.tools.push(RuntimeItem {
+                        path: e.path(),
+                        app_id: None,
+                        reason: "Missing proton executable".to_string(),
+                        selected: false,
+                        verified: false,
+                    });
+                }
+            }
+        }
+    }
+
+    results
+}
+
+pub fn delete_item(item: &RuntimeItem) -> std::io::Result<()> {
+    fs::remove_dir_all(&item.path)
+}


### PR DESCRIPTION
## Summary
- add `parse_appmanifest_installdir` helper
- implement runtime cleanup scanning utilities
- add RuntimeCleanerWindow to GUI
- add 'Steam Runtime Cleaner' button in the app

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68549483e2b88333887c0bc071d16bc3