### PR TITLE
Disable window placement persistence

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,8 @@ fn main() {
                 .viewport
                 .with_decorations(true)
                 .with_inner_size(egui::vec2(1200.0, 800.0));
+            // Let the OS decide where to place the window
+            native_options.persist_window = false;
             eframe::run_native(
                 "Proton Prefix Manager",
                 native_options,


### PR DESCRIPTION
## Summary
- let the OS manage the initial window position by turning off persisted window location

## Testing
- `cargo test`
- `cargo fmt -- --check`

------
https://chatgpt.com/codex/tasks/task_e_68549a7b64ac833397f5e83f46de7773