### PR TITLE
Add icons to toolbar and center GUI window

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -256,7 +256,7 @@ impl eframe::App for ProtonPrefixManagerApp {
                         self.toggle_theme(ctx);
                     }
                     if ui
-                        .small_button("🔎")
+                        .button("🔎 Advanced Search")
                         .on_hover_text("Advanced Search")
                         .clicked()
                     {
@@ -266,14 +266,14 @@ impl eframe::App for ProtonPrefixManagerApp {
                         self.show_advanced_search = true;
                     }
                     if ui
-                        .button("Manage Backups")
+                        .button("💾 Manage Backups")
                         .on_hover_text("View and manage backups for all games.")
                         .clicked()
                     {
                         self.show_backup_manager = true;
                     }
                     if ui
-                        .button("Steam Runtime Cleaner")
+                        .button("🧹 Steam Runtime Cleaner")
                         .on_hover_text("Find leftover data to delete.")
                         .clicked()
                     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,7 @@ fn main() {
                 .viewport
                 .with_decorations(true)
                 .with_inner_size(egui::vec2(1200.0, 800.0));
+            native_options.centered = true;
             // Let the OS decide where to place the window
             native_options.persist_window = false;
             eframe::run_native(


### PR DESCRIPTION
## Summary
- give each top toolbar button an icon
- replace advanced search icon with `🔎 Advanced Search` text
- center the GUI window on launch

## Testing
- `cargo test --no-run --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68549f0129c88333b937b4b51d4184b9