### PR TITLE
Add tooltip to unverified custom Proton items

### DIFF
--- a/src/gui/runtime_cleaner.rs
+++ b/src/gui/runtime_cleaner.rs
@@ -187,7 +187,8 @@ impl RuntimeCleanerWindow {
                         if !item.verified {
                             ui.label(
                                 egui::RichText::new("[unverified]").color(egui::Color32::YELLOW),
-                            );
+                            )
+                            .on_hover_text("Could not verify this is a valid Proton version.");
                         }
                     });
                 }


### PR DESCRIPTION
## Summary
- show tooltip for unverified custom Proton versions in runtime cleaner

## Testing
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_6854a156f1148333a3d52185012f2c21