### PR TITLE
Fix repair dialog quoting

### DIFF
--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -529,7 +529,7 @@ impl<'a> GameDetails<'a> {
                     if ui.button("Repair Prefix").clicked() {
                         if tfd::message_box_yes_no(
                             "Repair Prefix",
-                            "This will recreate missing directories and run 'wineboot' to regenerate registry files. Continue?",
+                            "This will recreate missing directories and run wineboot to regenerate registry files. Continue?",
                             tfd::MessageBoxIcon::Question,
                             tfd::YesNo::Yes,
                         ) == tfd::YesNo::Yes


### PR DESCRIPTION
## Summary
- fix quoting issue in the repair prefix confirmation dialog

## Testing
- `cargo fmt -- --check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6854a336623c8333b631755750326f5b