### PR TITLE
Fix repair modal size

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -491,6 +491,7 @@ impl eframe::App for ProtonPrefixManagerApp {
             Modal::new(egui::Id::new("repair_modal"))
                 .frame(egui::Frame::window(&ctx.style()))
                 .show(ctx, |ui| {
+                    ui.set_min_width(200.0);
                     ui.centered_and_justified(|ui| {
                         ui.spinner();
                         ui.label("Repairing prefix...");


### PR DESCRIPTION
## Summary
- ensure the repair modal has a minimum width so its height doesn't keep growing

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6854bcf6a3388333956a7261edf9e845