### PR TITLE
Add debug logging for prefix repair and validation

### DIFF
--- a/src/utils/prefix_repair.rs
+++ b/src/utils/prefix_repair.rs
@@ -9,16 +9,23 @@ use crate::error::{Error, Result};
 /// This will recreate critical folders and run `wineboot` to
 /// regenerate missing registry files.
 pub fn repair_prefix(prefix: &Path) -> Result<()> {
+    log::debug!("repairing prefix at {:?}", prefix);
     let pfx = prefix.join("pfx");
     if !pfx.exists() {
+        log::debug!("creating {:?}", pfx);
         fs::create_dir_all(&pfx)?;
     }
     // Ensure core directories exist
-    fs::create_dir_all(pfx.join("drive_c"))?;
-    fs::create_dir_all(pfx.join("dosdevices"))?;
+    let drive_c = pfx.join("drive_c");
+    let dosdevices = pfx.join("dosdevices");
+    log::debug!("ensuring {:?} exists", drive_c);
+    fs::create_dir_all(&drive_c)?;
+    log::debug!("ensuring {:?} exists", dosdevices);
+    fs::create_dir_all(&dosdevices)?;
     let _ = fs::File::create(pfx.join(".update-timestamp"));
 
     // Run wineboot to regenerate registry files
+    log::debug!("running wineboot for {:?}", pfx);
     let status = Command::new("wineboot")
         .env("WINEPREFIX", &pfx)
         .status()


### PR DESCRIPTION
## Summary
- add debug statements in `repair_prefix`
- log validation steps in `validate_prefix`
- log helper functions used by prefix validator

## Testing
- `cargo fmt --all`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6854c42a4dd883338ee736bf2b01cd5e