### PR TITLE
Fix runtime lookup across all libraries

### DIFF
--- a/src/utils/steam_paths.rs
+++ b/src/utils/steam_paths.rs
@@ -89,5 +89,18 @@ pub fn compatibilitytools_dirs() -> Vec<PathBuf> {
             }
         }
     }
+
+    if let Ok(libraries) = crate::core::steam::get_steam_libraries() {
+        for lib in libraries {
+            let p = lib.path().join("compatibilitytools.d");
+            if p.exists() {
+                let canon = fs::canonicalize(&p).unwrap_or(p.clone());
+                if seen.insert(canon.clone()) {
+                    dirs.push(canon);
+                }
+            }
+        }
+    }
+
     dirs
 }


### PR DESCRIPTION
## Summary
- search all Steam library folders for compatibility tools

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6854ca02f65483339dd05e9478e5132d