### PR TITLE
Expand launch options field

### DIFF
--- a/src/gui/details.rs
+++ b/src/gui/details.rs
@@ -577,7 +577,8 @@ impl<'a> GameDetails<'a> {
                     });
                     ui.horizontal(|ui| {
                         ui.label("Launch Options:");
-                        ui.add(
+                        ui.add_sized(
+                            [300.0, 0.0],
                             egui::TextEdit::singleline(&mut cfg.launch_options)
                                 .id_salt("launch_options")
                                 .hint_text("e.g. PROTON_LOG=1"),


### PR DESCRIPTION
## Summary
- expand the launch options input box by giving it a fixed width

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6855ddb43e708333ad5fbb951c95d08f