### PR TITLE
Fix sorting in game list and advanced search

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -1,8 +1,9 @@
 use super::advanced_search::{advanced_search_dialog, AdvancedSearchState};
 use super::backup_manager::BackupManagerWindow;
 use super::details::{Action, GameConfig, GameDetails, PrefixInfo};
-use super::game_list::{compare_games, GameList};
+use super::game_list::GameList;
 use super::runtime_cleaner::RuntimeCleanerWindow;
+use super::sort::sort_games;
 use super::SortOption;
 use crate::core::models::GameInfo;
 use crate::core::steam;
@@ -123,8 +124,8 @@ impl ProtonPrefixManagerApp {
     }
 
     fn sort_filtered_games(&mut self) {
-        let opt = self.sort_option;
-        self.filtered_games.sort_by(|a, b| compare_games(a, b, opt));
+        let (key, desc) = self.sort_option.as_key();
+        sort_games(&mut self.filtered_games, key, desc);
     }
 
     fn search_games(&mut self) {

--- a/src/gui/game_list.rs
+++ b/src/gui/game_list.rs
@@ -1,6 +1,6 @@
+use super::sort::GameSortKey;
 use crate::core::models::GameInfo;
 use eframe::egui;
-use std::cmp::Ordering;
 
 /// Available sort options for the game list
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -22,24 +22,13 @@ impl SortOption {
     }
 }
 
-pub(super) fn compare_games(a: &GameInfo, b: &GameInfo, sort: SortOption) -> Ordering {
-    match sort {
-        SortOption::NameAsc => a
-            .name()
-            .to_lowercase()
-            .cmp(&b.name().to_lowercase()),
-        SortOption::NameDesc => b
-            .name()
-            .to_lowercase()
-            .cmp(&a.name().to_lowercase()),
-        SortOption::ModifiedAsc | SortOption::ModifiedDesc => {
-            let ta = a.modified();
-            let tb = b.modified();
-            if matches!(sort, SortOption::ModifiedAsc) {
-                ta.cmp(&tb)
-            } else {
-                tb.cmp(&ta)
-            }
+impl SortOption {
+    pub(crate) fn as_key(self) -> (GameSortKey, bool) {
+        match self {
+            SortOption::NameAsc => (GameSortKey::Name, false),
+            SortOption::NameDesc => (GameSortKey::Name, true),
+            SortOption::ModifiedAsc => (GameSortKey::Modified, false),
+            SortOption::ModifiedDesc => (GameSortKey::Modified, true),
         }
     }
 }
@@ -69,10 +58,26 @@ impl<'a> GameList<'a> {
                 egui::ComboBox::from_id_salt("sort_combo")
                     .selected_text(sort_option.label())
                     .show_ui(ui, |ui| {
-                        ui.selectable_value(sort_option, SortOption::ModifiedDesc, SortOption::ModifiedDesc.label());
-                        ui.selectable_value(sort_option, SortOption::ModifiedAsc, SortOption::ModifiedAsc.label());
-                        ui.selectable_value(sort_option, SortOption::NameAsc, SortOption::NameAsc.label());
-                        ui.selectable_value(sort_option, SortOption::NameDesc, SortOption::NameDesc.label());
+                        ui.selectable_value(
+                            sort_option,
+                            SortOption::ModifiedDesc,
+                            SortOption::ModifiedDesc.label(),
+                        );
+                        ui.selectable_value(
+                            sort_option,
+                            SortOption::ModifiedAsc,
+                            SortOption::ModifiedAsc.label(),
+                        );
+                        ui.selectable_value(
+                            sort_option,
+                            SortOption::NameAsc,
+                            SortOption::NameAsc.label(),
+                        );
+                        ui.selectable_value(
+                            sort_option,
+                            SortOption::NameDesc,
+                            SortOption::NameDesc.label(),
+                        );
                     });
                 if *sort_option != prev {
                     changed = true;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -4,6 +4,7 @@ mod backup_manager;
 mod details;
 mod game_list;
 mod runtime_cleaner;
+mod sort;
 
 pub use game_list::SortOption;
 

--- a/src/gui/sort.rs
+++ b/src/gui/sort.rs
@@ -1,0 +1,26 @@
+use crate::core::models::GameInfo;
+use std::cmp::Ordering;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum GameSortKey {
+    Name,
+    Modified,
+    LastPlayed,
+    AppId,
+}
+
+pub fn compare_games(a: &GameInfo, b: &GameInfo, key: GameSortKey) -> Ordering {
+    match key {
+        GameSortKey::Name => a.name().to_lowercase().cmp(&b.name().to_lowercase()),
+        GameSortKey::Modified => a.modified().cmp(&b.modified()),
+        GameSortKey::LastPlayed => a.last_played().cmp(&b.last_played()),
+        GameSortKey::AppId => a.app_id().cmp(&b.app_id()),
+    }
+}
+
+pub fn sort_games(games: &mut [GameInfo], key: GameSortKey, descending: bool) {
+    games.sort_by(|a, b| compare_games(a, b, key));
+    if descending {
+        games.reverse();
+    }
+}


### PR DESCRIPTION
## Summary
- centralize game sorting logic into new `sort` module
- use unified sorting for the main game list and advanced search

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6855ddfc2b2c83338c488eb0aea56de7